### PR TITLE
fix: Transfer manager when user is the operator

### DIFF
--- a/contracts/TransferManager.sol
+++ b/contracts/TransferManager.sol
@@ -220,7 +220,7 @@ contract TransferManager is ITransferManager, OwnableTwoSteps {
      * @param operator address of the operator
      */
     function _isTransferValid(address user, address operator) internal view returns (bool) {
-        return _whitelistedOperators[operator] && _hasUserApprovedOperator[user][operator];
+        return user == operator || (_whitelistedOperators[operator] && _hasUserApprovedOperator[user][operator]);
     }
 
     /**


### PR DESCRIPTION
The current code prevents us to use the transfer manager as a standalone contract to offer transfer sand batch transfers features outside if the trading system. If the operator is the owner (i.e `from == msg.sender`), then the whitelist check is not relevant.