### PR TITLE
perf: No need to "delete" discount factor

### DIFF
--- a/contracts/CollectionDiscountManager.sol
+++ b/contracts/CollectionDiscountManager.sol
@@ -28,11 +28,7 @@ contract CollectionDiscountManager is ICollectionDiscountManager, OwnableTwoStep
         if (msg.sender != collectionDiscountController) revert NotCollectionDiscountController();
         if (discountFactor > 10000) revert CollectionDiscountFactorTooHigh();
 
-        if (discountFactor != 0) {
-            collectionDiscountFactor[collection] = discountFactor;
-        } else {
-            delete collectionDiscountFactor[collection];
-        }
+        collectionDiscountFactor[collection] = discountFactor;
 
         emit NewCollectionDiscountFactor(collection, discountFactor);
     }


### PR DESCRIPTION
```
testTakerAskERC721WithoutProtocolFeeNorRoyalty() (gas: -34 (-0.003%))
testTakerBidERC721WithoutProtocolFeeNorRoyalty() (gas: -34 (-0.003%))
Overall gas change: -68 (-0.007%)
```

Since setting it to 0 is the same as `delete`, it saves a few gas without having to do an `if/else`