### PR TITLE
perf: Named return vars for isValid

### DIFF
--- a/contracts/executionStrategies/StrategyDutchAuction.sol
+++ b/contracts/executionStrategies/StrategyDutchAuction.sol
@@ -74,17 +74,21 @@ contract StrategyDutchAuction is StrategyBase {
      *         the maker order is invalid. Instead it returns false and the error's 4 bytes selector.
      * @param makerAsk Maker ask struct (contains the maker bid-specific parameters for the execution of the transaction)
      * @dev The client has to provide the seller's desired initial start price as the additionalParameters.
+     * @return orderIsValid Whether the maker struct is valid
+     * @return errorSelector If isValid is false, return the error's 4 bytes selector
      */
-    function isValid(OrderStructs.MakerAsk calldata makerAsk) external pure returns (bool, bytes4) {
+    function isValid(
+        OrderStructs.MakerAsk calldata makerAsk
+    ) external pure returns (bool orderIsValid, bytes4 errorSelector) {
         uint256 itemIdsLength = makerAsk.itemIds.length;
 
         if (itemIdsLength == 0 || itemIdsLength != makerAsk.amounts.length) {
-            return (false, OrderInvalid.selector);
+            return (orderIsValid, OrderInvalid.selector);
         }
         for (uint256 i; i < itemIdsLength; ) {
             uint256 amount = makerAsk.amounts[i];
             if (amount == 0) {
-                return (false, OrderInvalid.selector);
+                return (orderIsValid, OrderInvalid.selector);
             }
 
             unchecked {
@@ -95,9 +99,9 @@ contract StrategyDutchAuction is StrategyBase {
         uint256 startPrice = abi.decode(makerAsk.additionalParameters, (uint256));
 
         if (startPrice < makerAsk.minPrice) {
-            return (false, OrderInvalid.selector);
+            return (orderIsValid, OrderInvalid.selector);
         }
 
-        return (true, bytes4(0));
+        orderIsValid = true;
     }
 }

--- a/contracts/executionStrategies/StrategyTokenIdsRange.sol
+++ b/contracts/executionStrategies/StrategyTokenIdsRange.sol
@@ -81,14 +81,18 @@ contract StrategyTokenIdsRange is StrategyBase {
      * @notice Validate the *only the maker* order under the context of the chosen strategy. It does not revert if
      *         the maker order is invalid. Instead it returns false and the error's 4 bytes selector.
      * @param makerBid Maker bid struct (contains the maker bid-specific parameters for the execution of the transaction)
+     * @return orderIsValid Whether the maker struct is valid
+     * @return errorSelector If isValid is false, return the error's 4 bytes selector
      */
-    function isValid(OrderStructs.MakerBid calldata makerBid) external pure returns (bool, bytes4) {
+    function isValid(
+        OrderStructs.MakerBid calldata makerBid
+    ) external pure returns (bool orderIsValid, bytes4 errorSelector) {
         uint256 minTokenId = makerBid.itemIds[0];
         uint256 maxTokenId = makerBid.itemIds[1];
         if (minTokenId >= maxTokenId) {
-            return (false, OrderInvalid.selector);
+            return (orderIsValid, OrderInvalid.selector);
         }
 
-        return (true, bytes4(0));
+        orderIsValid = true;
     }
 }

--- a/contracts/executionStrategies/StrategyUSDDynamicAsk.sol
+++ b/contracts/executionStrategies/StrategyUSDDynamicAsk.sol
@@ -86,22 +86,26 @@ contract StrategyUSDDynamicAsk is StrategyChainlinkPriceLatency {
      * @notice Validate the *only the maker* order under the context of the chosen strategy. It does not revert if
      *         the maker order is invalid. Instead it returns false and the error's 4 bytes selector.
      * @param makerAsk Maker ask struct (contains the maker ask-specific parameters for the execution of the transaction)
+     * @return orderIsValid Whether the maker struct is valid
+     * @return errorSelector If isValid is false, return the error's 4 bytes selector
      */
-    function isValid(OrderStructs.MakerAsk calldata makerAsk) external view returns (bool, bytes4) {
+    function isValid(
+        OrderStructs.MakerAsk calldata makerAsk
+    ) external view returns (bool orderIsValid, bytes4 errorSelector) {
         uint256 itemIdsLength = makerAsk.itemIds.length;
 
         if (itemIdsLength == 0 || itemIdsLength != makerAsk.amounts.length) {
-            return (false, OrderInvalid.selector);
+            return (orderIsValid, OrderInvalid.selector);
         }
 
         (, int256 answer, , uint256 updatedAt, ) = priceFeed.latestRoundData();
         if (answer <= 0) {
-            return (false, InvalidChainlinkPrice.selector);
+            return (orderIsValid, InvalidChainlinkPrice.selector);
         }
         if (block.timestamp - updatedAt > maximumLatency) {
-            return (false, PriceNotRecentEnough.selector);
+            return (orderIsValid, PriceNotRecentEnough.selector);
         }
 
-        return (true, bytes4(0));
+        orderIsValid = true;
     }
 }


### PR DESCRIPTION
It saves a few gas per tx

```
testChainlinkPriceLessThanOrEqualToZero() (gas: -2 (-0.000%))
testChainlinkPriceLessThanOrEqualToZero() (gas: -2 (-0.000%))
testFloorBasedCollectionOfferDesiredDiscountedAmountGreaterThanOrEqualToFloorPrice() (gas: -2 (-0.000%))
testOraclePriceNotRecentEnough() (gas: -2 (-0.000%))
testItemIdsAndAmountsLengthMismatch() (gas: -2 (-0.000%))
testPriceFeedNotAvailable() (gas: -2 (-0.000%))
testOraclePriceNotRecentEnough() (gas: -2 (-0.000%))
testOraclePriceNotRecentEnough() (gas: -2 (-0.000%))
testPriceFeedNotAvailable() (gas: -2 (-0.000%))
testZeroItemIdsLength() (gas: -2 (-0.000%))
testUSDDynamicAskInvalidChainlinkPrice() (gas: -4 (-0.000%))
testFloorPremiumDesiredSalePriceLessThanMinPrice() (gas: -5 (-0.001%))
testFloorPremiumDesiredSalePriceGreaterThanOrEqualToMinPrice() (gas: -5 (-0.001%))
testFloorBasedCollectionOfferDesiredDiscountedPriceLessThanMaxPrice() (gas: -5 (-0.001%))
testFloorBasedCollectionOfferDesiredDiscountedPriceGreaterThanOrEqualToMaxPrice() (gas: -5 (-0.001%))
testUSDDynamicAskUSDValueLessThanMinAcceptedEthValue() (gas: -5 (-0.001%))
testUSDDynamicAskUSDValueLessThanOneETH() (gas: -5 (-0.001%))
testUSDDynamicAskUSDValueGreaterThanOrEqualToMinAcceptedEthValue() (gas: -5 (-0.001%))
testUSDDynamicAskBidderOverpaid() (gas: -5 (-0.001%))
testBidTooLow() (gas: -5 (-0.001%))
testMakerAskTakerBidItemIdsMismatch() (gas: -5 (-0.001%))
testTakerBidAmountNotOne() (gas: -5 (-0.001%))
testMakerBidTooLow() (gas: -5 (-0.001%))
testTakerBidTooLow() (gas: -5 (-0.001%))
testItemIdsMismatch() (gas: -5 (-0.001%))
testCallerNotLooksRareProtocol() (gas: -5 (-0.001%))
testTakerAskZeroAmount() (gas: -5 (-0.001%))
testZeroAmount() (gas: -5 (-0.001%))
testTakerAskAmountsLengthNotOne() (gas: -5 (-0.001%))
testTakerAskItemIdsLengthNotOne() (gas: -5 (-0.001%))
testCallerNotLooksRareProtocol() (gas: -5 (-0.001%))
testCallerNotLooksRareProtocol() (gas: -5 (-0.001%))
testMakerAskAmountNotOne() (gas: -8 (-0.001%))
testMakerAskAmountsLengthNotOne() (gas: -8 (-0.001%))
testMakerAskItemIdsLengthNotOne() (gas: -8 (-0.001%))
testMakerBidAmountNotOne() (gas: -8 (-0.001%))
testFloorPremiumDesiredSalePriceLessThanMinPrice() (gas: -5 (-0.001%))
testFloorPremiumDesiredSalePriceGreaterThanOrEqualToMinPrice() (gas: -5 (-0.001%))
testMakerBidAmountsLengthNotOne() (gas: -8 (-0.001%))
testTokenIdsRangeERC721() (gas: -1005 (-0.046%))
testTakerAskForceAmountOneIfERC721() (gas: -1005 (-0.046%))
testMakerBidItemIdsLowerBandHigherThanOrEqualToUpperBand() (gas: -1002 (-0.047%))
testTokenIdsRangeERC1155() (gas: -1005 (-0.048%))
testTakerAskUnsortedItemIds() (gas: -1005 (-0.049%))
testTakerAskDuplicatedItemIds() (gas: -1005 (-0.049%))
testTakerAskPriceTooHigh() (gas: -1005 (-0.049%))
testTakerAskOfferedAmountNotEqualToDesiredAmount() (gas: -1005 (-0.050%))
testCallerNotLooksRareProtocol() (gas: -1005 (-0.050%))
testDutchAuction(uint256) (gas: -1808 (-0.087%))
testItemIdsAndAmountsLengthMismatch() (gas: -1805 (-0.089%))
testTakerBidTooLow(uint256) (gas: -1808 (-0.091%))
testStartPriceTooLow() (gas: -1805 (-0.091%))
testItemIdsMismatch() (gas: -1808 (-0.091%))
testZeroAmount() (gas: -1805 (-0.092%))
testCallerNotLooksRareProtocol() (gas: -1811 (-0.098%))
testZeroItemIdsLength() (gas: -1805 (-0.102%))
testNewStrategy() (gas: -1000 (-0.107%))
testNewStrategy() (gas: -1806 (-0.179%))
Overall gas change: -26482 (-1.487%)
```