### PR TITLE
refactor: Contract libs update

### DIFF
--- a/contracts/LooksRareProtocol.sol
+++ b/contracts/LooksRareProtocol.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.17;
 // LooksRare unopinionated libraries
 import {SignatureChecker} from "@looksrare/contracts-libs/contracts/SignatureChecker.sol";
 import {ReentrancyGuard} from "@looksrare/contracts-libs/contracts/ReentrancyGuard.sol";
-import {LowLevelETH} from "@looksrare/contracts-libs/contracts/lowLevelCallers/LowLevelETH.sol";
+import {LowLevelETHReturnETHIfAnyExceptOneWei} from "@looksrare/contracts-libs/contracts/lowLevelCallers/LowLevelETHReturnETHIfAnyExceptOneWei.sol";
 import {LowLevelWETH} from "@looksrare/contracts-libs/contracts/lowLevelCallers/LowLevelWETH.sol";
 import {LowLevelERC20Transfer} from "@looksrare/contracts-libs/contracts/lowLevelCallers/LowLevelERC20Transfer.sol";
 
@@ -38,10 +38,9 @@ contract LooksRareProtocol is
     AffiliateManager,
     TransferSelectorNFT,
     ReentrancyGuard,
-    LowLevelETH,
+    LowLevelETHReturnETHIfAnyExceptOneWei,
     LowLevelWETH,
-    LowLevelERC20Transfer,
-    SignatureChecker
+    LowLevelERC20Transfer
 {
     using OrderStructs for OrderStructs.MakerAsk;
     using OrderStructs for OrderStructs.MakerBid;
@@ -518,7 +517,7 @@ contract LooksRareProtocol is
     ) internal view {
         // \x19\x01 is the encoding prefix
         bytes32 digest = keccak256(abi.encodePacked("\x19\x01", domainSeparator, computedHash));
-        _verify(digest, signer, makerSignature);
+        SignatureChecker.verify(digest, signer, makerSignature);
     }
 
     /**

--- a/contracts/helpers/OrderValidator.sol
+++ b/contracts/helpers/OrderValidator.sol
@@ -33,7 +33,7 @@ import "./ValidationCodeConstants.sol";
  *         7. Other potential restrictions where it can tap into specific contracts with specific validation codes
  * @author LooksRare protocol team (👀,💎)
  */
-contract OrderValidator is SignatureChecker {
+contract OrderValidator {
     using OrderStructs for OrderStructs.MakerAsk;
     using OrderStructs for OrderStructs.MakerBid;
     using OrderStructs for OrderStructs.MerkleRoot;

--- a/contracts/helpers/ProtocolHelpers.sol
+++ b/contracts/helpers/ProtocolHelpers.sol
@@ -15,7 +15,7 @@ import {LooksRareProtocol} from "../LooksRareProtocol.sol";
  * @notice This contract contains helper view functions for order creation.
  * @author LooksRare protocol team (👀,💎)
  */
-contract ProtocolHelpers is SignatureChecker {
+contract ProtocolHelpers {
     using OrderStructs for OrderStructs.MakerAsk;
     using OrderStructs for OrderStructs.MakerBid;
     using OrderStructs for OrderStructs.MerkleRoot;
@@ -75,7 +75,7 @@ contract ProtocolHelpers is SignatureChecker {
         address signer
     ) public view returns (bool) {
         bytes32 digest = computeDigestMakerAsk(makerAsk);
-        _verify(digest, signer, makerSignature);
+        SignatureChecker.verify(digest, signer, makerSignature);
         return true;
     }
 
@@ -91,7 +91,7 @@ contract ProtocolHelpers is SignatureChecker {
         address signer
     ) public view returns (bool) {
         bytes32 digest = computeDigestMakerBid(makerBid);
-        _verify(digest, signer, makerSignature);
+        SignatureChecker.verify(digest, signer, makerSignature);
         return true;
     }
 
@@ -107,7 +107,7 @@ contract ProtocolHelpers is SignatureChecker {
         address signer
     ) public view returns (bool) {
         bytes32 digest = computeDigestMerkleRoot(merkleRoot);
-        _verify(digest, signer, makerSignature);
+        SignatureChecker.verify(digest, signer, makerSignature);
         return true;
     }
 }

--- a/package.json
+++ b/package.json
@@ -76,6 +76,6 @@
   },
   "dependencies": {
     "@chainlink/contracts": "^0.5.1",
-    "@looksrare/contracts-libs": "^2.3.0"
+    "@looksrare/contracts-libs": "^2.4.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1034,10 +1034,10 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@looksrare/contracts-libs@^2.3.0":
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/@looksrare/contracts-libs/-/contracts-libs-2.3.0.tgz#e829e30c46a64d9784685cee30b713a2e4102357"
-  integrity sha512-hgWmq+dN45e2nNqIV55J7AmtkG5OCOuNuEbvw4xbRJN6xlKf3+1Ge8Wn9RvvKtH5rlr+QS/MXLR9z9Zegcvegw==
+"@looksrare/contracts-libs@^2.4.1":
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/@looksrare/contracts-libs/-/contracts-libs-2.4.1.tgz#4b9e4d8ab6b689dc29e28e038148355bb32e2118"
+  integrity sha512-1QLtd6dFaUQQiPOWhaOAT/FUGpO/oGAzKAU1IhVfdQvrqBFmQiq3DPZUUkvhJbQMBInxp1kzIcCLc04+Oz/kDg==
 
 "@metamask/eth-sig-util@^4.0.0":
   version "4.0.1"


### PR DESCRIPTION
This PR aims at reducing the codesize for `LooksRareProtocol`.

- Split each function into a stand-alone contract (from contract-libs) from `LowLevelETH`
- `SignatureChecker` becomes a library