### PR TITLE
perf: Make countStrategies and strategyId uint256

### DIFF
--- a/contracts/StrategyManager.sol
+++ b/contracts/StrategyManager.sol
@@ -79,7 +79,7 @@ contract StrategyManager is IStrategyManager, OwnableTwoSteps {
      * @param isActive Whether the strategy is active
      */
     function updateStrategy(
-        uint16 strategyId,
+        uint256 strategyId,
         uint16 newStandardProtocolFee,
         uint16 newMinTotalFee,
         bool isActive

--- a/contracts/interfaces/IStrategyManager.sol
+++ b/contracts/interfaces/IStrategyManager.sol
@@ -13,7 +13,7 @@ interface IStrategyManager {
 
     // Events
     event NewStrategy(uint256 strategyId, address implementation);
-    event StrategyUpdated(uint16 strategyId, bool isActive, uint16 standardProtocolFee, uint16 minTotalFee);
+    event StrategyUpdated(uint256 strategyId, bool isActive, uint16 standardProtocolFee, uint16 minTotalFee);
 
     // Custom structs
     struct Strategy {

--- a/test/foundry/ExecutionManager.t.sol
+++ b/test/foundry/ExecutionManager.t.sol
@@ -13,7 +13,7 @@ contract ExecutionManagerTest is ProtocolBase, IExecutionManager, IStrategyManag
      * Owner can change protocol fee and deactivate royalty
      */
     function testOwnerCanChangeStrategyProtocolFeeAndDeactivateRoyalty() public asPrankedUser(_owner) {
-        uint16 strategyId = 0;
+        uint256 strategyId = 0;
         uint16 standardProtocolFee = 250;
         uint16 minTotalFee = 250;
         bool isActive = true;
@@ -45,7 +45,7 @@ contract ExecutionManagerTest is ProtocolBase, IExecutionManager, IStrategyManag
      * Owner can discontinue strategy
      */
     function testOwnerCanDiscontinueStrategy() public asPrankedUser(_owner) {
-        uint16 strategyId = 0;
+        uint256 strategyId = 0;
         uint16 standardProtocolFee = 299;
         uint16 minTotalFee = 250;
         bool isActive = false;


### PR DESCRIPTION
However, if I also convert the `strategyId` in `MakerBid` and `MakerAsk` `uint256`, the gas consumption spikes so I've stopped here. It will require more investigations.

```
testTakerBidMultipleOrdersSignedERC721() (gas: -22 (-0.000%))
testTakerAskMultipleOrdersSignedERC721() (gas: -22 (-0.000%))
testTakerAskERC721BundleWithRoyaltiesFromRegistry() (gas: -22 (-0.001%))
testTakerBidERC721BundleWithRoyaltiesFromRegistry() (gas: -22 (-0.001%))
testTakerAskERC721BundleNoRoyalties() (gas: -22 (-0.001%))
testTakerBidERC721BundleNoRoyalties() (gas: -22 (-0.001%))
testTakerAskERC721WithRoyaltiesFromRegistry() (gas: -22 (-0.002%))
testTakerBidERC721WithRoyaltiesFromRegistry() (gas: -22 (-0.002%))
testFloorFromChainlinkPremiumWrongCurrency() (gas: 23 (0.003%))
testFloorFromChainlinkPremiumWrongCurrency() (gas: 23 (0.003%))
testFloorFromChainlinkDiscountWrongCurrency() (gas: 23 (0.003%))
testFloorFromChainlinkDiscountWrongCurrency() (gas: 23 (0.003%))
testCannotExecuteOrderIfWrongUserGlobalBidNonce() (gas: -22 (-0.004%))
testCannotExecuteOrderIfWrongUserGlobalAskNonce() (gas: -22 (-0.004%))
testTakerAskERC721WithAffiliateButWithoutRoyalty() (gas: -88 (-0.008%))
testTakerBidERC721WithAffiliateButWithoutRoyalty() (gas: -88 (-0.008%))
testFloorFromChainlinkPremiumFixedAmountDesiredSalePriceLessThanMinPrice() (gas: -72 (-0.008%))
testFloorFromChainlinkPremiumFixedAmountDesiredSalePriceEqualToMinPrice() (gas: -72 (-0.008%))
testFloorFromChainlinkPremiumFixedAmountDesiredSalePriceGreaterThanMinPrice() (gas: -72 (-0.008%))
testMultipleTakerBidsERC721WithAffiliateButWithoutRoyalty() (gas: 153 (0.010%))
testCannotExecuteAnotherOrderAtNonceIfExecutionIsInProgress() (gas: -233 (-0.010%))
testMultiFill() (gas: -277 (-0.011%))
testTokenIdsRangeERC721() (gas: -233 (-0.011%))
testTakerAskForceAmountOneIfERC721() (gas: -233 (-0.011%))
testMakerBidItemIdsLowerBandHigherThanOrEqualToUpperBand() (gas: -233 (-0.011%))
testTokenIdsRangeERC1155() (gas: -233 (-0.011%))
testDutchAuction(uint256) (gas: -233 (-0.011%))
testTakerAskUnsortedItemIds() (gas: -233 (-0.011%))
testTakerAskDuplicatedItemIds() (gas: -233 (-0.011%))
testTakerAskPriceTooHigh() (gas: -233 (-0.011%))
testItemIdsAndAmountsLengthMismatch() (gas: -233 (-0.011%))
testTakerAskOfferedAmountNotEqualToDesiredAmount() (gas: -233 (-0.012%))
testCallerNotLooksRareProtocol() (gas: -233 (-0.012%))
testTakerBidTooLow(uint256) (gas: -233 (-0.012%))
testItemIdsMismatch() (gas: -233 (-0.012%))
testStartPriceTooLow() (gas: -233 (-0.012%))
testZeroAmount() (gas: -233 (-0.012%))
testCallerNotLooksRareProtocol() (gas: -233 (-0.013%))
testThreeTakerBidsERC721() (gas: 109 (0.013%))
testZeroItemIdsLength() (gas: -233 (-0.013%))
testThreeTakerBidsERC721OneFails() (gas: 152 (0.014%))
testTakerAskCollectionOrderWithMerkleTreeERC721() (gas: -488 (-0.017%))
testFloorFromChainlinkPremiumBasisPointsDesiredSalePriceLessThanMinPrice() (gas: -72 (-0.017%))
testTakerAskCollectionOrderERC721(uint256) (gas: -488 (-0.023%))
testNewStrategy() (gas: -305 (-0.026%))
testWrongOrderFormat() (gas: -466 (-0.030%))
testNewStrategy() (gas: -305 (-0.030%))
testNewStrategy() (gas: -305 (-0.033%))
testNewStrategies() (gas: -610 (-0.057%))
testOwnerRevertionsForWrongParametersAddStrategy() (gas: -66 (-0.258%))
testInitialStates() (gas: -72 (-0.375%))
testNewStrategy() (gas: -72 (-0.399%))
testNewStrategy() (gas: -72 (-0.400%))
testNewStrategy() (gas: -72 (-0.400%))
testNewStrategy() (gas: -72 (-0.400%))
testNewStrategy() (gas: -72 (-0.450%))
testOwnerCanDiscontinueStrategy() (gas: -202 (-0.551%))
testOwnerCanChangeStrategyProtocolFeeAndDeactivateRoyalty() (gas: -202 (-0.551%))
Overall gas change: -8518 (-4.243%)
```