### PR TITLE
perf: User subset nonce use uint256 over bool

### DIFF
--- a/contracts/LooksRareProtocol.sol
+++ b/contracts/LooksRareProtocol.sol
@@ -252,7 +252,7 @@ contract LooksRareProtocol is
             // Verify nonces
             if (
                 userBidAskNonces[signer].bidNonce != makerBid.bidNonce ||
-                userSubsetNonce[signer][makerBid.subsetNonce] != bytes32(0) ||
+                userSubsetNonce[signer][makerBid.subsetNonce] != 0 ||
                 (userOrderNonceStatus != bytes32(0) && userOrderNonceStatus != orderHash)
             ) revert WrongNonces();
         }
@@ -312,7 +312,7 @@ contract LooksRareProtocol is
 
             if (
                 userBidAskNonces[signer].askNonce != makerAsk.askNonce ||
-                userSubsetNonce[signer][makerAsk.subsetNonce] != bytes32(0) ||
+                userSubsetNonce[signer][makerAsk.subsetNonce] != 0 ||
                 (userOrderNonceStatus != bytes32(0) && userOrderNonceStatus != orderHash)
             ) revert WrongNonces();
         }

--- a/contracts/NonceManager.sol
+++ b/contracts/NonceManager.sol
@@ -25,7 +25,7 @@ contract NonceManager is INonceManager {
     mapping(address => mapping(uint256 => bytes32)) public userOrderNonce;
 
     // Check whether the subset nonce for a user was cancelled
-    mapping(address => mapping(uint112 => bytes32)) public userSubsetNonce;
+    mapping(address => mapping(uint112 => uint256)) public userSubsetNonce;
 
     /**
      * @notice Cancel order nonces
@@ -53,7 +53,7 @@ contract NonceManager is INonceManager {
         if (subsetNonces.length == 0) revert WrongLengths();
 
         for (uint256 i; i < subsetNonces.length; ) {
-            userSubsetNonce[msg.sender][subsetNonces[i]] = MAGIC_VALUE_NONCE_EXECUTED;
+            userSubsetNonce[msg.sender][subsetNonces[i]] = 1;
             unchecked {
                 ++i;
             }

--- a/contracts/helpers/OrderValidator.sol
+++ b/contracts/helpers/OrderValidator.sol
@@ -140,7 +140,7 @@ contract OrderValidator {
         if (makerAsk.askNonce > globalAskNonce) return USER_GLOBAL_ASK_NONCE_LOWER;
 
         // 2. Check subset nonce
-        if (looksRareProtocol.userSubsetNonce(makerAsk.signer, makerAsk.subsetNonce) != bytes32(0))
+        if (looksRareProtocol.userSubsetNonce(makerAsk.signer, makerAsk.subsetNonce) != 0)
             return USER_SUBSET_NONCE_CANCELLED;
 
         // 3. Check order nonce
@@ -161,7 +161,7 @@ contract OrderValidator {
         if (makerBid.bidNonce > globalBidNonce) return USER_GLOBAL_ASK_NONCE_LOWER;
 
         // 2. Check subset nonce
-        if (looksRareProtocol.userSubsetNonce(makerBid.signer, makerBid.subsetNonce) != bytes32(0))
+        if (looksRareProtocol.userSubsetNonce(makerBid.signer, makerBid.subsetNonce) != 0)
             return USER_SUBSET_NONCE_CANCELLED;
 
         // 3. Check order nonce


### PR DESCRIPTION
Based on the aggregator's automatic code finding from C4, it is cheaper to use `uint256` instead of `bool` for storage as it requires conversion for `bool`. Not sure if worth it, but I will throw the idea out there first. I've also made the check `!= 0` (not false) instead of `== 1` (== true) in case for some reason there is another piece of code that "accidentally" sets it to a nonzero value that's not 1.

`testCannotExecuteOrderIfSubsetNonceIsUsed() (gas: -33 (-0.006%))`