### PR TITLE
fix: CurrencyManager uses uint256 over bool

### DIFF
--- a/contracts/CurrencyManager.sol
+++ b/contracts/CurrencyManager.sol
@@ -14,7 +14,7 @@ import {ICurrencyManager} from "./interfaces/ICurrencyManager.sol";
  */
 contract CurrencyManager is ICurrencyManager, OwnableTwoSteps {
     // Check whether the currency is whitelisted
-    mapping(address => bool) public isCurrencyWhitelisted;
+    mapping(address => uint256) public isCurrencyWhitelisted;
 
     /**
      * @notice Whitelist/blacklist currency for execution
@@ -22,7 +22,12 @@ contract CurrencyManager is ICurrencyManager, OwnableTwoSteps {
      * @param isWhitelisted Whether the currency is whitelisted
      */
     function updateCurrencyWhitelistStatus(address currency, bool isWhitelisted) external onlyOwner {
-        isCurrencyWhitelisted[currency] = isWhitelisted;
+        uint256 isWhitelistedUint;
+        // 1 if true, 0 if false
+        assembly {
+            isWhitelistedUint := isWhitelisted
+        }
+        isCurrencyWhitelisted[currency] = isWhitelistedUint;
         emit CurrencyWhitelistStatusUpdated(currency, isWhitelisted);
     }
 }

--- a/contracts/LooksRareProtocol.sol
+++ b/contracts/LooksRareProtocol.sol
@@ -83,7 +83,7 @@ contract LooksRareProtocol is
         address affiliate
     ) external nonReentrant {
         // Verify whether the currency is whitelisted but is not ETH (address(0))
-        if (!isCurrencyWhitelisted[makerBid.currency] || makerBid.currency == address(0)) revert WrongCurrency();
+        if (isCurrencyWhitelisted[makerBid.currency] == 0 || makerBid.currency == address(0)) revert WrongCurrency();
 
         address signer = makerBid.signer;
         bytes32 orderHash = makerBid.hash();
@@ -112,7 +112,7 @@ contract LooksRareProtocol is
         address affiliate
     ) external payable nonReentrant {
         // Verify whether the currency is whitelisted
-        if (!isCurrencyWhitelisted[makerAsk.currency]) revert WrongCurrency();
+        if (isCurrencyWhitelisted[makerAsk.currency] == 0) revert WrongCurrency();
 
         bytes32 orderHash = makerAsk.hash();
         _verifyMerkleProofOrOrderHash(merkleTree, orderHash, makerSignature, makerAsk.signer);
@@ -155,7 +155,7 @@ contract LooksRareProtocol is
         }
 
         // Verify whether the currency at array = 0 is whitelisted
-        if (!isCurrencyWhitelisted[makerAsks[0].currency]) revert WrongCurrency();
+        if (isCurrencyWhitelisted[makerAsks[0].currency] == 0) revert WrongCurrency();
 
         {
             // Initialize protocol fee

--- a/contracts/helpers/OrderValidator.sol
+++ b/contracts/helpers/OrderValidator.sol
@@ -177,7 +177,7 @@ contract OrderValidator {
         OrderStructs.MakerAsk calldata makerAsk
     ) public view returns (uint256 validationCode) {
         // Verify whether the currency is whitelisted
-        if (!looksRareProtocol.isCurrencyWhitelisted(makerAsk.currency)) return CURRENCY_NOT_WHITELISTED;
+        if (looksRareProtocol.isCurrencyWhitelisted(makerAsk.currency) == 0) return CURRENCY_NOT_WHITELISTED;
 
         // Verify whether the strategy is valid
         (
@@ -206,7 +206,7 @@ contract OrderValidator {
         OrderStructs.MakerBid calldata makerBid
     ) public view returns (uint256 validationCode) {
         // Verify whether the currency is whitelisted
-        if (!looksRareProtocol.isCurrencyWhitelisted(makerBid.currency)) return CURRENCY_NOT_WHITELISTED;
+        if (looksRareProtocol.isCurrencyWhitelisted(makerBid.currency) == 0) return CURRENCY_NOT_WHITELISTED;
 
         // Verify whether the strategy is valid
         (

--- a/test/foundry/CurrencyManager.t.sol
+++ b/test/foundry/CurrencyManager.t.sol
@@ -22,13 +22,13 @@ contract CurrencyManagerTest is TestHelpers, TestParameters, ICurrencyManager {
         vm.expectEmit(true, false, false, true);
         emit CurrencyWhitelistStatusUpdated(address(mockERC20), true);
         currencyManager.updateCurrencyWhitelistStatus(address(mockERC20), true);
-        assertTrue(currencyManager.isCurrencyWhitelisted(address(mockERC20)));
+        assertTrue(currencyManager.isCurrencyWhitelisted(address(mockERC20)) == 1);
 
         // Set to false
         vm.expectEmit(true, false, false, true);
         emit CurrencyWhitelistStatusUpdated(address(mockERC20), false);
         currencyManager.updateCurrencyWhitelistStatus(address(mockERC20), false);
-        assertFalse(currencyManager.isCurrencyWhitelisted(address(mockERC20)));
+        assertTrue(currencyManager.isCurrencyWhitelisted(address(mockERC20)) == 0);
     }
 
     function testupdateCurrencyWhitelistStatusNotOwner() public {


### PR DESCRIPTION
UPDATE (using assembly to cast bool into 1 or 0):

24698 -> 24691

```
testTakerAskMultipleOrdersSignedERC721() (gas: -6 (-0.000%))
testTakerAskCollectionOrderWithMerkleTreeERC721() (gas: -6 (-0.000%))
testTokenIdsRangeERC721() (gas: -6 (-0.000%))
testTakerAskForceAmountOneIfERC721() (gas: -6 (-0.000%))
testTokenIdsRangeERC1155() (gas: -6 (-0.000%))
testTakerAskCollectionOrderERC721(uint256) (gas: -6 (-0.000%))
testTakerAskUnsortedItemIds() (gas: -6 (-0.000%))
testTakerAskDuplicatedItemIds() (gas: -6 (-0.000%))
testTakerAskPriceTooHigh() (gas: -6 (-0.000%))
testTakerAskOfferedAmountNotEqualToDesiredAmount() (gas: -6 (-0.000%))
testCreatorRoyaltiesGetPaidForERC2981WithBundles() (gas: -6 (-0.000%))
testCreatorRoyaltiesGetPaidForRoyaltyFeeManagerWithBundles() (gas: -6 (-0.000%))
testTakerAskERC721BundleWithRoyaltiesFromRegistry() (gas: -6 (-0.000%))
testWrongOrderFormat() (gas: -6 (-0.000%))
testTakerAskERC721BundleNoRoyalties() (gas: -6 (-0.000%))
testCreatorRoyaltiesRevertIfFeeHigherThanLimit() (gas: -6 (-0.000%))
testMultiFill() (gas: -12 (-0.000%))
testCannotExecuteAnotherOrderAtNonceIfExecutionIsInProgress() (gas: -12 (-0.001%))
testCreatorRoyaltiesGetPaidForRoyaltyFeeManager() (gas: -6 (-0.001%))
testTakerAskERC721WithRoyaltiesFromRegistry() (gas: -6 (-0.001%))
testMakerBidItemIdsLowerBandHigherThanOrEqualToUpperBand() (gas: -12 (-0.001%))
testCreatorRoyaltiesGetPaidForERC2981() (gas: -6 (-0.001%))
testCannotExecuteAnOrderWhoseNonceIsCancelled() (gas: -6 (-0.001%))
testFloorFromChainlinkDiscountFixedAmountDesiredDiscountedPriceGreaterThanOrEqualToMaxPrice() (gas: -6 (-0.001%))
testFloorFromChainlinkDiscountFixedAmountDesiredDiscountedPriceLessThanMaxPrice() (gas: -6 (-0.001%))
testCreatorRoyaltiesRevertForEIP2981WithBundlesIfInfoDiffer() (gas: -12 (-0.001%))
testFloorFromChainlinkDiscountBasisPointsDesiredDiscountedPriceGreaterThanOrEqualToMaxPrice() (gas: -6 (-0.001%))
testFloorFromChainlinkDiscountBasisPointsDesiredDiscountedPriceLessThanMaxPrice() (gas: -6 (-0.001%))
testMultipleTakerBidsERC721WithAffiliateButWithoutRoyalty() (gas: -11 (-0.001%))
testFloorFromChainlinkDiscountAskTooHigh() (gas: -6 (-0.001%))
testFloorFromChainlinkDiscountAskTooHigh() (gas: -6 (-0.001%))
testFloorFromChainlinkDiscountOraclePriceNotRecentEnough() (gas: -6 (-0.001%))
testFloorFromChainlinkDiscountOraclePriceNotRecentEnough() (gas: -6 (-0.001%))
testFloorFromChainlinkDiscountMakerBidAmountNotOne() (gas: -6 (-0.001%))
testFloorFromChainlinkDiscountMakerBidAmountNotOne() (gas: -6 (-0.001%))
testFloorFromChainlinkDiscountTakerAskZeroAmount() (gas: -6 (-0.001%))
testFloorFromChainlinkDiscountTakerAskZeroAmount() (gas: -6 (-0.001%))
testFloorFromChainlinkDiscountTakerAskAmountsLengthNotOne() (gas: -6 (-0.001%))
testFloorFromChainlinkDiscountTakerAskItemIdsLengthNotOne() (gas: -6 (-0.001%))
testFloorFromChainlinkDiscountTakerAskAmountsLengthNotOne() (gas: -6 (-0.001%))
testFloorFromChainlinkDiscountTakerAskItemIdsLengthNotOne() (gas: -6 (-0.001%))
testFloorFromChainlinkDiscountPriceFeedNotAvailable() (gas: -6 (-0.001%))
testFloorFromChainlinkDiscountPriceFeedNotAvailable() (gas: -6 (-0.001%))
testFloorFromChainlinkDiscountBasisPointsDesiredDiscountBasisPointsGreaterThan10000() (gas: -6 (-0.001%))
testFloorFromChainlinkDiscountMakerBidAmountsLengthNotOne() (gas: -6 (-0.001%))
testFloorFromChainlinkDiscountMakerBidAmountsLengthNotOne() (gas: -6 (-0.001%))
testTakerBidERC721WithAffiliateButWithoutRoyalty() (gas: -11 (-0.001%))
testCannotExecuteOrderIfWrongUserGlobalBidNonce() (gas: -6 (-0.001%))
testCannotExecuteAnOrderTwice() (gas: -12 (-0.001%))
testFloorFromChainlinkPremiumWrongCurrency() (gas: -10 (-0.001%))
testFloorFromChainlinkPremiumWrongCurrency() (gas: -10 (-0.001%))
testFloorFromChainlinkDiscountChainlinkPriceLessThanOrEqualToZero() (gas: -12 (-0.001%))
testFloorFromChainlinkDiscountChainlinkPriceLessThanOrEqualToZero() (gas: -12 (-0.001%))
testFloorFromChainlinkDiscountFixedAmountDesiredDiscountedAmountGreaterThanOrEqualToFloorPrice() (gas: -12 (-0.002%))
testTakerAskERC721WithAffiliateButWithoutRoyalty() (gas: -17 (-0.002%))
testFloorFromChainlinkDiscountWrongCurrency() (gas: -16 (-0.002%))
testFloorFromChainlinkDiscountWrongCurrency() (gas: -16 (-0.002%))
testCannotValidateOrderIfWrongFormat() (gas: -36 (-0.003%))
testCannotValidateOrderIfWrongTimestamps() (gas: -18 (-0.003%))
testupdateCurrencyWhitelistStatus() (gas: -188 (-0.555%))
Overall gas change: -681 (-0.605%)
```