### PR TITLE
fix: TransferManager uses uint256 over bool

### DIFF
--- a/contracts/TransferManager.sol
+++ b/contracts/TransferManager.sol
@@ -208,6 +208,6 @@ contract TransferManager is ITransferManager, LowLevelERC721Transfer, LowLevelER
      * @param operator Operator address
      */
     function isOperatorValidForTransfer(address user, address operator) internal view returns (bool) {
-        return isOperatorWhitelisted[operator] != 0 && hasUserApprovedOperator[user][operator] != 0;
+        return (isOperatorWhitelisted[operator] & hasUserApprovedOperator[user][operator]) != 0;
     }
 }


### PR DESCRIPTION
No contract size change for this one but there are some gas savings

```
testTakerBidMultipleOrdersSignedERC721() (gas: -375 (-0.000%))
testTakerAskMultipleOrdersSignedERC721() (gas: -375 (-0.000%))
testFloorFromChainlinkPremiumFixedAmountDesiredSalePriceLessThanMinPrice() (gas: -97 (-0.011%))
testFloorFromChainlinkPremiumFixedAmountDesiredSalePriceGreaterThanMinPrice() (gas: -97 (-0.011%))
testFloorFromChainlinkPremiumFixedAmountDesiredSalePriceEqualToMinPrice() (gas: -97 (-0.011%))
testFloorFromChainlinkDiscountFixedAmountDesiredDiscountedPriceGreaterThanOrEqualToMaxPrice() (gas: -97 (-0.012%))
testFloorFromChainlinkDiscountFixedAmountDesiredDiscountedPriceLessThanMaxPrice() (gas: -97 (-0.012%))
testFloorFromChainlinkDiscountBasisPointsDesiredDiscountedPriceGreaterThanOrEqualToMaxPrice() (gas: -97 (-0.012%))
testFloorFromChainlinkDiscountBasisPointsDesiredDiscountedPriceLessThanMaxPrice() (gas: -97 (-0.012%))
testUSDDynamicAskUSDValueLessThanMinAcceptedEthValue() (gas: -97 (-0.012%))
testUSDDynamicAskUSDValueLessThanOneETH() (gas: -97 (-0.012%))
testUSDDynamicAskUSDValueGreaterThanOrEqualToMinAcceptedEthValue() (gas: -97 (-0.012%))
testUSDDynamicAskBidderOverpaid() (gas: -97 (-0.012%))
testTakerAskCollectionOrderWithMerkleTreeERC721() (gas: -375 (-0.013%))
testMakerBidItemIdsLowerBandHigherThanOrEqualToUpperBand() (gas: -278 (-0.013%))
testTakerAskUnsortedItemIds() (gas: -278 (-0.014%))
testTakerAskDuplicatedItemIds() (gas: -278 (-0.014%))
testTakerAskPriceTooHigh() (gas: -278 (-0.014%))
testItemIdsAndAmountsLengthMismatch() (gas: -278 (-0.014%))
testTakerAskOfferedAmountNotEqualToDesiredAmount() (gas: -278 (-0.014%))
testCallerNotLooksRareProtocol() (gas: -278 (-0.014%))
testTakerBidTooLow(uint256) (gas: -278 (-0.014%))
testItemIdsMismatch() (gas: -278 (-0.014%))
testStartPriceTooLow() (gas: -278 (-0.014%))
testZeroAmount() (gas: -278 (-0.014%))
testCallerNotLooksRareProtocol() (gas: -278 (-0.015%))
testZeroItemIdsLength() (gas: -278 (-0.016%))
testCreatorRoyaltiesRevertForEIP2981WithBundlesIfInfoDiffer() (gas: -278 (-0.017%))
testCannotExecuteAnotherOrderAtNonceIfExecutionIsInProgress() (gas: -375 (-0.017%))
testTokenIdsRangeERC721() (gas: -375 (-0.018%))
testTakerAskForceAmountOneIfERC721() (gas: -375 (-0.018%))
testTokenIdsRangeERC1155() (gas: -375 (-0.018%))
testTakerAskCollectionOrderERC721(uint256) (gas: -375 (-0.018%))
testDutchAuction(uint256) (gas: -375 (-0.018%))
testCreatorRoyaltiesRevertIfFeeHigherThanLimit() (gas: -278 (-0.020%))
testCreatorRoyaltiesGetPaidForERC2981WithBundles() (gas: -375 (-0.022%))
testFloorFromChainlinkPremiumBasisPointsDesiredSalePriceLessThanMinPrice() (gas: -97 (-0.023%))
testFloorFromChainlinkPremiumBasisPointsDesiredSalePriceGreaterThanMinPrice() (gas: -97 (-0.023%))
testFloorFromChainlinkPremiumBasisPointsDesiredSalePriceEqualToMinPrice() (gas: -97 (-0.023%))
testMultiFill() (gas: -611 (-0.024%))
testCreatorRoyaltiesGetPaidForRoyaltyFeeManagerWithBundles() (gas: -375 (-0.024%))
testTakerAskERC721BundleWithRoyaltiesFromRegistry() (gas: -375 (-0.024%))
testTakerBidERC721BundleWithRoyaltiesFromRegistry() (gas: -375 (-0.024%))
testTakerAskERC721BundleNoRoyalties() (gas: -375 (-0.025%))
testTakerBidERC721BundleNoRoyalties() (gas: -375 (-0.026%))
testCannotExecuteAnOrderWhoseNonceIsCancelled() (gas: -278 (-0.028%))
testTakerAskERC721WithAffiliateButWithoutRoyalty() (gas: -375 (-0.035%))
testTakerBidERC721WithAffiliateButWithoutRoyalty() (gas: -375 (-0.035%))
testCannotExecuteAnOrderTwice() (gas: -375 (-0.035%))
testCreatorRoyaltiesGetPaidForRoyaltyFeeManager() (gas: -375 (-0.035%))
testTakerAskERC721WithRoyaltiesFromRegistry() (gas: -375 (-0.036%))
testTakerBidERC721WithRoyaltiesFromRegistry() (gas: -375 (-0.036%))
testCreatorRoyaltiesGetPaidForERC2981() (gas: -375 (-0.036%))
testThreeTakerBidsERC721() (gas: -569 (-0.069%))
testMultipleTakerBidsERC721WithAffiliateButWithoutRoyalty() (gas: -1054 (-0.069%))
testThreeTakerBidsERC721OneFails() (gas: -860 (-0.079%))
testTransferBatchItemsAcrossCollectionERC721AndERC1155() (gas: -354 (-0.132%))
testTransferBatchItemsSameERC721() (gas: -354 (-0.157%))
testCannotTransferIfOperatorRemoved() (gas: -196 (-0.166%))
testTransferBatchItemsSameERC1155() (gas: -354 (-0.173%))
testTransferSingleItemERC721() (gas: -354 (-0.185%))
testCannotBatchTransferIfAssetTypeIsNotZeroOrOne() (gas: -257 (-0.189%))
testTransferSingleItemERC1155() (gas: -354 (-0.207%))
testCannotTransferIfApprovalsRemoved() (gas: -466 (-0.371%))
Overall gas change: -19839 (-2.784%)
```