### PR TITLE
perf: POC - ReentrancyGuard packing with other contracts

### DIFF
--- a/contracts/LooksRareProtocol.sol
+++ b/contracts/LooksRareProtocol.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.17;
 
 // LooksRare unopinionated libraries
 import {SignatureChecker} from "@looksrare/contracts-libs/contracts/SignatureChecker.sol";
-import {ReentrancyGuard} from "@looksrare/contracts-libs/contracts/ReentrancyGuard.sol";
+import {ReentrancyGuard} from "./libraries/ReentrancyGuard.sol";
 import {LowLevelETHReturnETHIfAnyExceptOneWei} from "@looksrare/contracts-libs/contracts/lowLevelCallers/LowLevelETHReturnETHIfAnyExceptOneWei.sol";
 import {LowLevelWETH} from "@looksrare/contracts-libs/contracts/lowLevelCallers/LowLevelWETH.sol";
 import {LowLevelERC20Transfer} from "@looksrare/contracts-libs/contracts/lowLevelCallers/LowLevelERC20Transfer.sol";
@@ -34,9 +34,9 @@ contract LooksRareProtocol is
     ILooksRareProtocol,
     CurrencyManager,
     ExecutionManager,
-    AffiliateManager,
-    TransferSelectorNFT,
     ReentrancyGuard,
+    TransferSelectorNFT,
+    AffiliateManager,
     LowLevelETHReturnETHIfAnyExceptOneWei,
     LowLevelWETH,
     LowLevelERC20Transfer

--- a/contracts/libraries/ReentrancyGuard.sol
+++ b/contracts/libraries/ReentrancyGuard.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.14;
+
+import {IReentrancyGuard} from "@looksrare/contracts-libs/contracts/interfaces/IReentrancyGuard.sol";
+
+/**
+ * @title ReentrancyGuard
+ * @notice This contract protects against reentrancy attacks.
+ *         It is adjusted from OpenZeppelin.
+ */
+abstract contract ReentrancyGuard is IReentrancyGuard {
+    uint8 private _status;
+
+    constructor() {
+        _status = 1;
+    }
+
+    /**
+     * @notice Modifier to wrap functions to prevent reentrancy calls
+     */
+    modifier nonReentrant() {
+        if (_status == 2) revert ReentrancyFail();
+
+        _status = 2;
+        _;
+        _status = 1;
+    }
+}

--- a/test/foundry/LooksRareProtocol.t.sol
+++ b/test/foundry/LooksRareProtocol.t.sol
@@ -12,7 +12,7 @@ contract LooksRareProtocolTest is ProtocolBase {
         vm.expectEmit(true, false, false, true);
         emit NewGasLimitETHTransfer(10_000);
         looksRareProtocol.adjustETHGasLimitForTransfer(10_000);
-        assertEq(uint256(vm.load(address(looksRareProtocol), bytes32(uint256(16)))), 10_000);
+        assertEq(uint256(vm.load(address(looksRareProtocol), bytes32(uint256(15)))), 10_000);
     }
 
     function testAdjustETHGasLimitForTransferNotOwner() public {


### PR DESCRIPTION
Just a proof of concept, but we can potentially squeeze more performance by packing ReentrancyGuard.status with other contracts storage slots (same contract in the end as they are LooksRareProtocol's parents). It costs more gas for failed trades but it costs less gas for successful trades. And successful trades should happen way more frequently then failed trades.

```
testTakerBidMultipleOrdersSignedERC721() (gas: -1753 (-0.000%))
testTakerAskMultipleOrdersSignedERC721() (gas: -1753 (-0.000%))
testTakerAskMultipleOrdersSignedERC721WrongMerkleProof() (gas: 132 (0.001%))
testTakerBidMultipleOrdersSignedERC721WrongMerkleProof() (gas: 132 (0.001%))
testInactiveStrategy() (gas: 132 (0.009%))
testTakerAskPriceTooHigh() (gas: 132 (0.009%))
testTakerAskUnsortedItemIds() (gas: 132 (0.009%))
testTakerAskDuplicatedItemIds() (gas: 132 (0.009%))
testTakerAskOfferedAmountNotEqualToDesiredAmount() (gas: 132 (0.009%))
testInactiveStrategy() (gas: 132 (0.009%))
testTakerBidTooLow(uint256) (gas: 132 (0.009%))
testStartPriceTooLow() (gas: 132 (0.009%))
testItemIdsMismatch() (gas: 132 (0.009%))
testItemIdsAndAmountsLengthMismatch() (gas: 132 (0.009%))
testZeroAmount() (gas: 132 (0.009%))
testInactiveStrategy() (gas: 132 (0.009%))
testZeroItemIdsLength() (gas: 132 (0.010%))
testExecuteMultipleTakerBidsReentrancy() (gas: 149 (0.014%))
testTakerBidReentrancy() (gas: 149 (0.014%))
testTakerAskReentrancy() (gas: 149 (0.015%))
testMakerBidItemIdsLowerBandHigherThanOrEqualToUpperBand() (gas: 264 (0.018%))
testCannotExecuteAnOrderWhoseNonceIsCancelled() (gas: 132 (0.024%))
testAdjustETHGasLimitForTransfer() (gas: -9 (-0.048%))
testFloorFromChainlinkDiscountWrongCurrency() (gas: 132 (0.062%))
testFloorFromChainlinkDiscountWrongCurrency() (gas: 132 (0.062%))
testFloorFromChainlinkDiscountAskTooHigh() (gas: 132 (0.062%))
testFloorFromChainlinkDiscountAskTooHigh() (gas: 132 (0.062%))
testFloorFromChainlinkPremiumWrongCurrency() (gas: 132 (0.063%))
testFloorFromChainlinkPremiumWrongCurrency() (gas: 132 (0.063%))
testFloorFromChainlinkPremiumBidTooLow() (gas: 132 (0.064%))
testFloorFromChainlinkPremiumBidTooLow() (gas: 132 (0.064%))
testInactiveStrategy() (gas: 132 (0.064%))
testFloorFromChainlinkDiscountTakerAskZeroAmount() (gas: 132 (0.064%))
testFloorFromChainlinkDiscountTakerAskZeroAmount() (gas: 132 (0.064%))
testFloorFromChainlinkDiscountTakerAskAmountsLengthNotOne() (gas: 132 (0.064%))
testFloorFromChainlinkDiscountTakerAskAmountsLengthNotOne() (gas: 132 (0.064%))
testFloorFromChainlinkDiscountTakerAskItemIdsLengthNotOne() (gas: 132 (0.064%))
testFloorFromChainlinkDiscountTakerAskItemIdsLengthNotOne() (gas: 132 (0.064%))
testInactiveStrategy() (gas: 132 (0.064%))
testFloorFromChainlinkDiscountBasisPointsDesiredDiscountBasisPointsGreaterThan10000() (gas: 132 (0.064%))
testInactiveStrategy() (gas: 132 (0.064%))
testInactiveStrategy() (gas: 132 (0.064%))
testFloorFromChainlinkPremiumTakerBidAmountNotOne() (gas: 132 (0.065%))
testFloorFromChainlinkPremiumTakerBidAmountNotOne() (gas: 132 (0.065%))
testFloorFromChainlinkPremiumMakerAskTakerBidItemIdsMismatch() (gas: 132 (0.065%))
testFloorFromChainlinkPremiumMakerAskTakerBidItemIdsMismatch() (gas: 132 (0.065%))
testFloorFromChainlinkDiscountOraclePriceNotRecentEnough() (gas: 132 (0.070%))
testFloorFromChainlinkDiscountOraclePriceNotRecentEnough() (gas: 132 (0.070%))
testFloorFromChainlinkDiscountMakerBidAmountNotOne() (gas: 132 (0.070%))
testFloorFromChainlinkDiscountMakerBidAmountNotOne() (gas: 132 (0.071%))
testFloorFromChainlinkDiscountMakerBidAmountsLengthNotOne() (gas: 132 (0.071%))
testFloorFromChainlinkDiscountMakerBidAmountsLengthNotOne() (gas: 132 (0.071%))
testFloorFromChainlinkPremiumOraclePriceNotRecentEnough() (gas: 132 (0.071%))
testFloorFromChainlinkPremiumOraclePriceNotRecentEnough() (gas: 132 (0.071%))
testFloorFromChainlinkPremiumMakerAskAmountNotOne() (gas: 132 (0.072%))
testFloorFromChainlinkPremiumMakerAskAmountNotOne() (gas: 132 (0.072%))
testFloorFromChainlinkPremiumMakerAskAmountsLengthNotOne() (gas: 132 (0.073%))
testFloorFromChainlinkPremiumMakerAskAmountsLengthNotOne() (gas: 132 (0.073%))
testFloorFromChainlinkPremiumMakerAskItemIdsLengthNotOne() (gas: 132 (0.073%))
testFloorFromChainlinkPremiumMakerAskItemIdsLengthNotOne() (gas: 132 (0.073%))
testTakerBidTooLow() (gas: 132 (0.074%))
testInactiveStrategy() (gas: 132 (0.075%))
testZeroAmount() (gas: 132 (0.076%))
testItemIdsMismatch() (gas: 132 (0.076%))
testMultiFill() (gas: -1506 (-0.078%))
testFloorFromChainlinkDiscountChainlinkPriceLessThanOrEqualToZero() (gas: 264 (0.078%))
testFloorFromChainlinkDiscountChainlinkPriceLessThanOrEqualToZero() (gas: 264 (0.078%))
testFloorFromChainlinkDiscountPriceFeedNotAvailable() (gas: 132 (0.080%))
testFloorFromChainlinkDiscountPriceFeedNotAvailable() (gas: 132 (0.080%))
testFloorFromChainlinkPremiumChainlinkPriceLessThanOrEqualToZero() (gas: 264 (0.080%))
testFloorFromChainlinkPremiumChainlinkPriceLessThanOrEqualToZero() (gas: 264 (0.080%))
testFloorFromChainlinkPremiumPriceFeedNotAvailable() (gas: 132 (0.082%))
testFloorFromChainlinkPremiumPriceFeedNotAvailable() (gas: 132 (0.082%))
testOraclePriceNotRecentEnough() (gas: 132 (0.086%))
testItemIdsAndAmountsLengthMismatch() (gas: 132 (0.086%))
testThreeTakerBidsERC721WrongLengths() (gas: 396 (0.091%))
testUSDDynamicAskInvalidChainlinkPrice() (gas: 264 (0.093%))
testCannotExecuteOrderIfWrongUserGlobalAskNonce() (gas: 132 (0.096%))
testCannotExecuteOrderIfSubsetNonceIsUsed() (gas: 132 (0.098%))
testCannotExecuteOrderIfWrongUserGlobalBidNonce() (gas: 132 (0.099%))
testFloorFromChainlinkDiscountFixedAmountDesiredDiscountedAmountGreaterThanOrEqualToFloorPrice() (gas: 264 (0.100%))
testCannotExecuteAnotherOrderAtNonceIfExecutionIsInProgress() (gas: -1621 (-0.101%))
testTakerAskForceAmountOneIfERC721() (gas: -1753 (-0.114%))
testTokenIdsRangeERC721() (gas: -1753 (-0.114%))
testDutchAuction(uint256) (gas: -1753 (-0.119%))
testTokenIdsRangeERC1155() (gas: -1753 (-0.122%))
testZeroItemIdsLength() (gas: 132 (0.132%))
testTakerAskCollectionOrderWithMerkleTreeERC721() (gas: -1753 (-0.142%))
testCreatorRoyaltiesGetPaidForERC2981WithBundles() (gas: -1753 (-0.173%))
testCreatorRoyaltiesGetPaidForERC2981WithBundles() (gas: -1753 (-0.188%))
testZeroAmount() (gas: 132 (0.189%))
testBidAskAmountMismatch() (gas: 132 (0.189%))
testPriceMismatch() (gas: 132 (0.191%))
testAmountsLengthNotOne() (gas: 264 (0.203%))
testAmountsMismatch() (gas: 264 (0.204%))
testItemIdsLengthNotOne() (gas: 264 (0.205%))
testTakerBidERC721BundleWithRoyaltiesFromRegistry() (gas: -1753 (-0.225%))
testThreeTakerBidsERC721() (gas: -1753 (-0.226%))
testCreatorRebatesArePaidForRoyaltyFeeManagerWithBundles() (gas: -1753 (-0.227%))
testCreatorRoyaltiesGetPaidForRoyaltyFeeManagerWithBundles() (gas: -1753 (-0.227%))
testTakerAskERC721BundleWithRoyaltiesFromRegistry() (gas: -1753 (-0.227%))
testCreatorRoyaltiesRevertForEIP2981WithBundlesIfInfoDiffer() (gas: -1868 (-0.230%))
testTakerBidERC721BundleNoRoyalties() (gas: -1753 (-0.251%))
testTakerAskERC721BundleNoRoyalties() (gas: -1753 (-0.254%))
testCannotExecuteAnOrderTwice() (gas: -1621 (-0.255%))
testTakerBidERC721WithRoyaltiesFromRegistry() (gas: -1753 (-0.257%))
testTakerAskERC721WithRoyaltiesFromRegistry() (gas: -1753 (-0.262%))
testCreatorRoyaltiesGetPaidForRoyaltyFeeManager() (gas: -1753 (-0.280%))
testCreatorRebatesArePaidForRoyaltyFeeManager() (gas: -1753 (-0.282%))
testCannotValidateOrderIfWrongTimestamps() (gas: 396 (0.287%))
testCannotValidateOrderIfWrongFormat() (gas: 1584 (0.288%))
testCreatorRoyaltiesGetPaidForERC2981() (gas: -1753 (-0.291%))
testCreatorRebatesArePaidForERC2981() (gas: -1753 (-0.293%))
testMultipleTakerBidsERC721WithAffiliateButWithoutRoyalty() (gas: -4553 (-0.315%))
testTakerAskCollectionOrderERC721(uint256) (gas: -1753 (-0.316%))
testThreeTakerBidsERC721OneFails() (gas: -3621 (-0.352%))
testThreeTakerBidsGasGriefing() (gas: -1753 (-0.357%))
testCreatorRoyaltiesRevertForEIP2981WithBundlesIfInfoDiffer() (gas: -3736 (-0.423%))
testTakerBidGasGriefing() (gas: -1753 (-0.546%))
testFloorFromChainlinkPremiumBasisPointsDesiredSalePriceLessThanMinPrice() (gas: -1753 (-0.561%))
testFloorFromChainlinkPremiumFixedAmountDesiredSalePriceEqualToMinPrice() (gas: -1753 (-0.562%))
testFloorFromChainlinkPremiumFixedAmountDesiredSalePriceLessThanMinPrice() (gas: -1753 (-0.562%))
testFloorFromChainlinkPremiumFixedAmountDesiredSalePriceGreaterThanMinPrice() (gas: -1753 (-0.562%))
testFloorFromChainlinkDiscountFixedAmountDesiredDiscountedPriceGreaterThanOrEqualToMaxPrice() (gas: -1753 (-0.563%))
testFloorFromChainlinkDiscountFixedAmountDesiredDiscountedPriceLessThanMaxPrice() (gas: -1753 (-0.563%))
testFloorFromChainlinkPremiumBasisPointsDesiredSalePriceEqualToMinPrice() (gas: -1753 (-0.565%))
testFloorFromChainlinkPremiumBasisPointsDesiredSalePriceGreaterThanMinPrice() (gas: -1753 (-0.565%))
testFloorFromChainlinkDiscountBasisPointsDesiredDiscountedPriceGreaterThanOrEqualToMaxPrice() (gas: -1753 (-0.566%))
testFloorFromChainlinkDiscountBasisPointsDesiredDiscountedPriceLessThanMaxPrice() (gas: -1753 (-0.570%))
testCreatorRoyaltiesRevertIfFeeHigherThanLimit() (gas: -3736 (-0.576%))
testUSDDynamicAskBidderOverpaid() (gas: -1753 (-0.618%))
testUSDDynamicAskUSDValueLessThanMinAcceptedEthValue() (gas: -1753 (-0.623%))
testUSDDynamicAskUSDValueLessThanOneETH() (gas: -1753 (-0.624%))
testUSDDynamicAskUSDValueGreaterThanOrEqualToMinAcceptedEthValue() (gas: -1753 (-0.624%))
testTakerBidERC721WithAffiliateButWithoutRoyalty() (gas: -4553 (-0.700%))
testTakerAskERC721WithAffiliateButWithoutRoyalty() (gas: -4553 (-0.709%))
Overall gas change: -85041 (-11.149%)
```