### PR TITLE
perf: Remove unnecessary scopes

### DIFF
--- a/contracts/LooksRareProtocol.sol
+++ b/contracts/LooksRareProtocol.sol
@@ -90,7 +90,7 @@ contract LooksRareProtocol is
 
         bytes32 orderHash = makerBid.hash();
         // Verify (1) MerkleProof (if necessary) (2) Signature is from the signer
-        if (merkleProof.length > 0) {
+        if (merkleProof.length != 0) {
             _verifyMerkleProofForOrderHash(merkleProof, merkleRoot.root, orderHash);
             _computeDigestAndVerify(merkleRoot.hash(), makerSignature, makerBid.signer);
         } else {
@@ -126,7 +126,7 @@ contract LooksRareProtocol is
 
         bytes32 orderHash = makerAsk.hash();
         // Verify (1) MerkleProof (if necessary) (2) Signature is from the signer
-        if (merkleProof.length > 0) {
+        if (merkleProof.length != 0) {
             _verifyMerkleProofForOrderHash(merkleProof, merkleRoot.root, orderHash);
             _computeDigestAndVerify(merkleRoot.hash(), makerSignature, makerAsk.signer);
         } else {
@@ -193,7 +193,7 @@ contract LooksRareProtocol is
 
                 {
                     // Verify (1) MerkleProof (if necessary) (2) Signature is from the signer
-                    if (merkleProofs[i].length > 0) {
+                    if (merkleProofs[i].length != 0) {
                         _verifyMerkleProofForOrderHash(merkleProofs[i], merkleRoots[i].root, orderHash);
                         _computeDigestAndVerify(merkleRoots[i].hash(), makerSignatures[i], makerAsk.signer);
                     } else {


### PR DESCRIPTION
```
testTakerBidMultipleOrdersSignedERC721() (gas: 2 (0.000%))
testTakerAskMultipleOrdersSignedERC721() (gas: 2 (0.000%))
testTakerAskCollectionOrderWithMerkleTreeERC721() (gas: -20 (-0.001%))
testTakerAskUnsortedItemIds() (gas: -17 (-0.001%))
testTakerAskDuplicatedItemIds() (gas: -17 (-0.001%))
testTakerAskPriceTooHigh() (gas: -17 (-0.001%))
testItemIdsAndAmountsLengthMismatch() (gas: -17 (-0.001%))
testTakerAskOfferedAmountNotEqualToDesiredAmount() (gas: -17 (-0.001%))
testTakerBidTooLow(uint256) (gas: -17 (-0.001%))
testItemIdsMismatch() (gas: -17 (-0.001%))
testStartPriceTooLow() (gas: -17 (-0.001%))
testZeroAmount() (gas: -17 (-0.001%))
testTokenIdsRangeERC721() (gas: -20 (-0.001%))
testTakerAskForceAmountOneIfERC721() (gas: -20 (-0.001%))
testTokenIdsRangeERC1155() (gas: -20 (-0.001%))
testZeroItemIdsLength() (gas: -17 (-0.001%))
testTakerAskCollectionOrderERC721(uint256) (gas: -20 (-0.001%))
testDutchAuction(uint256) (gas: -20 (-0.001%))
testWrongOrderFormat() (gas: -17 (-0.001%))
testTakerAskERC721BundleWithRoyaltiesFromRegistry() (gas: -20 (-0.001%))
testTakerBidERC721BundleWithRoyaltiesFromRegistry() (gas: -20 (-0.001%))
testTakerAskERC721BundleNoRoyalties() (gas: -20 (-0.001%))
testTakerBidERC721BundleNoRoyalties() (gas: -20 (-0.001%))
testMultiFill() (gas: -40 (-0.002%))
testMakerBidItemIdsLowerBandHigherThanOrEqualToUpperBand() (gas: -34 (-0.002%))
testCannotExecuteAnotherOrderAtNonceIfExecutionIsInProgress() (gas: -37 (-0.002%))
testCannotExecuteAnOrderWhoseNonceIsCancelled() (gas: -17 (-0.002%))
testTakerAskERC721WithAffiliateButWithoutRoyalty() (gas: -20 (-0.002%))
testTakerBidERC721WithAffiliateButWithoutRoyalty() (gas: -20 (-0.002%))
testTakerAskERC721WithRoyaltiesFromRegistry() (gas: -20 (-0.002%))
testTakerBidERC721WithRoyaltiesFromRegistry() (gas: -20 (-0.002%))
testFloorFromChainlinkPremiumWrongCurrency() (gas: -17 (-0.002%))
testFloorFromChainlinkPremiumWrongCurrency() (gas: -17 (-0.002%))
testFloorFromChainlinkPremiumBidTooLow() (gas: -17 (-0.002%))
testFloorFromChainlinkPremiumBidTooLow() (gas: -17 (-0.002%))
testFloorFromChainlinkPremiumMakerAskTakerBidItemIdsMismatch() (gas: -17 (-0.002%))
testFloorFromChainlinkPremiumMakerAskTakerBidItemIdsMismatch() (gas: -17 (-0.002%))
testFloorFromChainlinkDiscountWrongCurrency() (gas: -17 (-0.002%))
testFloorFromChainlinkDiscountWrongCurrency() (gas: -17 (-0.002%))
testItemIdsAndAmountsLengthMismatch() (gas: -17 (-0.002%))
testFloorFromChainlinkDiscountAskTooHigh() (gas: -17 (-0.002%))
testFloorFromChainlinkDiscountAskTooHigh() (gas: -17 (-0.002%))
testFloorFromChainlinkPremiumFixedAmountDesiredSalePriceLessThanMinPrice() (gas: -20 (-0.002%))
testFloorFromChainlinkPremiumOraclePriceNotRecentEnough() (gas: -17 (-0.002%))
testFloorFromChainlinkPremiumOraclePriceNotRecentEnough() (gas: -17 (-0.002%))
testFloorFromChainlinkPremiumTakerBidAmountNotOne() (gas: -17 (-0.002%))
testFloorFromChainlinkPremiumTakerBidAmountNotOne() (gas: -17 (-0.002%))
testFloorFromChainlinkPremiumFixedAmountDesiredSalePriceGreaterThanMinPrice() (gas: -20 (-0.002%))
testFloorFromChainlinkPremiumFixedAmountDesiredSalePriceEqualToMinPrice() (gas: -20 (-0.002%))
testTakerBidTooLow() (gas: -17 (-0.002%))
testFloorFromChainlinkDiscountFixedAmountDesiredDiscountedPriceGreaterThanOrEqualToMaxPrice() (gas: -20 (-0.002%))
testFloorFromChainlinkDiscountFixedAmountDesiredDiscountedPriceLessThanMaxPrice() (gas: -20 (-0.002%))
testItemIdsMismatch() (gas: -17 (-0.002%))
testFloorFromChainlinkDiscountOraclePriceNotRecentEnough() (gas: -17 (-0.002%))
testFloorFromChainlinkDiscountBasisPointsDesiredDiscountedPriceGreaterThanOrEqualToMaxPrice() (gas: -20 (-0.002%))
testFloorFromChainlinkDiscountOraclePriceNotRecentEnough() (gas: -17 (-0.002%))
testFloorFromChainlinkDiscountMakerBidAmountNotOne() (gas: -17 (-0.002%))
testFloorFromChainlinkDiscountMakerBidAmountNotOne() (gas: -17 (-0.002%))
testFloorFromChainlinkDiscountTakerAskZeroAmount() (gas: -17 (-0.002%))
testFloorFromChainlinkDiscountTakerAskZeroAmount() (gas: -17 (-0.002%))
testFloorFromChainlinkDiscountBasisPointsDesiredDiscountedPriceLessThanMaxPrice() (gas: -20 (-0.002%))
testFloorFromChainlinkPremiumMakerAskAmountNotOne() (gas: -17 (-0.002%))
testFloorFromChainlinkPremiumMakerAskAmountNotOne() (gas: -17 (-0.002%))
testFloorFromChainlinkPremiumPriceFeedNotAvailable() (gas: -17 (-0.002%))
testFloorFromChainlinkPremiumPriceFeedNotAvailable() (gas: -17 (-0.002%))
testUSDDynamicAskUSDValueLessThanMinAcceptedEthValue() (gas: -20 (-0.002%))
testUSDDynamicAskUSDValueLessThanOneETH() (gas: -20 (-0.002%))
testUSDDynamicAskUSDValueGreaterThanOrEqualToMinAcceptedEthValue() (gas: -20 (-0.002%))
testZeroAmount() (gas: -17 (-0.002%))
testOraclePriceNotRecentEnough() (gas: -17 (-0.002%))
testFloorFromChainlinkDiscountTakerAskAmountsLengthNotOne() (gas: -17 (-0.002%))
testFloorFromChainlinkDiscountTakerAskItemIdsLengthNotOne() (gas: -17 (-0.002%))
testFloorFromChainlinkDiscountTakerAskAmountsLengthNotOne() (gas: -17 (-0.002%))
testFloorFromChainlinkDiscountTakerAskItemIdsLengthNotOne() (gas: -17 (-0.002%))
testFloorFromChainlinkDiscountPriceFeedNotAvailable() (gas: -17 (-0.002%))
testFloorFromChainlinkDiscountPriceFeedNotAvailable() (gas: -17 (-0.002%))
testFloorFromChainlinkDiscountBasisPointsDesiredDiscountBasisPointsGreaterThan10000() (gas: -17 (-0.002%))
testUSDDynamicAskBidderOverpaid() (gas: -20 (-0.002%))
testFloorFromChainlinkPremiumMakerAskAmountsLengthNotOne() (gas: -17 (-0.002%))
testFloorFromChainlinkPremiumMakerAskAmountsLengthNotOne() (gas: -17 (-0.002%))
testFloorFromChainlinkPremiumMakerAskItemIdsLengthNotOne() (gas: -17 (-0.002%))
testFloorFromChainlinkPremiumMakerAskItemIdsLengthNotOne() (gas: -17 (-0.002%))
testFloorFromChainlinkDiscountMakerBidAmountsLengthNotOne() (gas: -17 (-0.003%))
testFloorFromChainlinkDiscountMakerBidAmountsLengthNotOne() (gas: -17 (-0.003%))
testCannotExecuteOrderIfWrongUserGlobalBidNonce() (gas: -17 (-0.003%))
testCannotExecuteOrderIfWrongUserGlobalAskNonce() (gas: -17 (-0.003%))
testCannotExecuteOrderIfSubsetNonceIsUsed() (gas: -17 (-0.003%))
testCannotExecuteAnOrderTwice() (gas: -37 (-0.003%))
testZeroItemIdsLength() (gas: -17 (-0.004%))
testFloorFromChainlinkPremiumChainlinkPriceLessThanOrEqualToZero() (gas: -34 (-0.004%))
testFloorFromChainlinkPremiumChainlinkPriceLessThanOrEqualToZero() (gas: -34 (-0.004%))
testFloorFromChainlinkDiscountChainlinkPriceLessThanOrEqualToZero() (gas: -34 (-0.004%))
testFloorFromChainlinkDiscountChainlinkPriceLessThanOrEqualToZero() (gas: -34 (-0.004%))
testUSDDynamicAskInvalidChainlinkPrice() (gas: -34 (-0.004%))
testFloorFromChainlinkDiscountFixedAmountDesiredDiscountedAmountGreaterThanOrEqualToFloorPrice() (gas: -34 (-0.004%))
testFloorFromChainlinkPremiumBasisPointsDesiredSalePriceLessThanMinPrice() (gas: -20 (-0.005%))
testFloorFromChainlinkPremiumBasisPointsDesiredSalePriceGreaterThanMinPrice() (gas: -20 (-0.005%))
testFloorFromChainlinkPremiumBasisPointsDesiredSalePriceEqualToMinPrice() (gas: -20 (-0.005%))
testThreeTakerBidsERC721() (gas: -42 (-0.005%))
testMultipleTakerBidsERC721WithAffiliateButWithoutRoyalty() (gas: -112 (-0.007%))
testThreeTakerBidsERC721OneFails() (gas: -84 (-0.008%))
testCannotValidateOrderIfWrongTimestamps() (gas: -51 (-0.009%))
testCannotValidateOrderIfWrongFormat() (gas: -204 (-0.015%))
Overall gas change: -2387 (-0.260%)
```

contract size down as well