### PR TITLE
perf: Recipients and fees are always of length 3

### DIFF
--- a/contracts/ExecutionManager.sol
+++ b/contracts/ExecutionManager.sol
@@ -75,15 +75,12 @@ contract ExecutionManager is InheritedStrategies, NonceManager, StrategyManager,
         returns (
             uint256[] memory itemIds,
             uint256[] memory amounts,
-            address[] memory recipients,
-            uint256[] memory fees,
+            address[3] memory recipients,
+            uint256[3] memory fees,
             bool isNonceInvalidated
         )
     {
         uint256 price;
-
-        recipients = new address[](3);
-        fees = new uint256[](3);
 
         (price, itemIds, amounts, isNonceInvalidated) = _executeStrategyHooksForTakerAsk(takerAsk, makerBid);
 
@@ -130,15 +127,12 @@ contract ExecutionManager is InheritedStrategies, NonceManager, StrategyManager,
         returns (
             uint256[] memory itemIds,
             uint256[] memory amounts,
-            address[] memory recipients,
-            uint256[] memory fees,
+            address[3] memory recipients,
+            uint256[3] memory fees,
             bool isNonceInvalidated
         )
     {
         uint256 price;
-
-        recipients = new address[](3);
-        fees = new uint256[](3);
 
         (price, itemIds, amounts, isNonceInvalidated) = _executeStrategyHooksForTakerBid(takerBid, makerAsk);
 

--- a/contracts/LooksRareProtocol.sol
+++ b/contracts/LooksRareProtocol.sol
@@ -280,8 +280,8 @@ contract LooksRareProtocol is
         (
             uint256[] memory itemIds,
             uint256[] memory amounts,
-            address[] memory recipients,
-            uint256[] memory fees,
+            address[3] memory recipients,
+            uint256[3] memory fees,
             bool isNonceInvalidated
         ) = _executeStrategyForTakerAsk(takerAsk, makerBid, msg.sender);
 
@@ -361,8 +361,8 @@ contract LooksRareProtocol is
         (
             uint256[] memory itemIds,
             uint256[] memory amounts,
-            address[] memory recipients,
-            uint256[] memory fees,
+            address[3] memory recipients,
+            uint256[3] memory fees,
             bool isNonceInvalidated
         ) = _executeStrategyForTakerBid(takerBid, makerAsk);
 

--- a/contracts/interfaces/ILooksRareProtocol.sol
+++ b/contracts/interfaces/ILooksRareProtocol.sol
@@ -32,8 +32,8 @@ interface ILooksRareProtocol {
         address collection,
         uint256[] itemIds,
         uint256[] amounts,
-        address[] feeRecipients,
-        uint256[] feeAmounts
+        address[3] feeRecipients,
+        uint256[3] feeAmounts
     );
 
     event TakerAsk(
@@ -44,7 +44,7 @@ interface ILooksRareProtocol {
         address collection,
         uint256[] itemIds,
         uint256[] amounts,
-        address[] feeRecipients,
-        uint256[] feeAmounts
+        address[3] feeRecipients,
+        uint256[3] feeAmounts
     );
 }


### PR DESCRIPTION
1. contract size down from 28506 to 27353
2.

```
testTakerBidMultipleOrdersSignedERC721() (gas: -1823 (-0.000%))
testTakerAskMultipleOrdersSignedERC721() (gas: -1838 (-0.000%))
testTakerAskUnsortedItemIds() (gas: -27 (-0.001%))
testTakerAskDuplicatedItemIds() (gas: -27 (-0.001%))
testTakerAskPriceTooHigh() (gas: -27 (-0.001%))
testItemIdsAndAmountsLengthMismatch() (gas: -27 (-0.001%))
testTakerBidTooLow(uint256) (gas: -27 (-0.001%))
testItemIdsMismatch() (gas: -27 (-0.001%))
testStartPriceTooLow() (gas: -27 (-0.001%))
testZeroAmount() (gas: -27 (-0.001%))
testTakerAskOfferedAmountNotEqualToDesiredAmount() (gas: -28 (-0.001%))
testZeroItemIdsLength() (gas: -27 (-0.002%))
testWrongOrderFormat() (gas: -27 (-0.002%))
testMakerBidItemIdsLowerBandHigherThanOrEqualToUpperBand() (gas: -54 (-0.003%))
testCreatorRoyaltiesRevertForEIP2981WithBundlesIfInfoDiffer() (gas: -54 (-0.003%))
testFloorFromChainlinkPremiumWrongCurrency() (gas: -27 (-0.004%))
testFloorFromChainlinkPremiumWrongCurrency() (gas: -27 (-0.004%))
testFloorFromChainlinkPremiumBidTooLow() (gas: -27 (-0.004%))
testFloorFromChainlinkPremiumBidTooLow() (gas: -27 (-0.004%))
testFloorFromChainlinkPremiumMakerAskTakerBidItemIdsMismatch() (gas: -27 (-0.004%))
testFloorFromChainlinkPremiumMakerAskTakerBidItemIdsMismatch() (gas: -27 (-0.004%))
testFloorFromChainlinkDiscountWrongCurrency() (gas: -27 (-0.004%))
testFloorFromChainlinkDiscountWrongCurrency() (gas: -27 (-0.004%))
testItemIdsAndAmountsLengthMismatch() (gas: -27 (-0.004%))
testFloorFromChainlinkDiscountAskTooHigh() (gas: -27 (-0.004%))
testFloorFromChainlinkDiscountAskTooHigh() (gas: -27 (-0.004%))
testFloorFromChainlinkPremiumOraclePriceNotRecentEnough() (gas: -27 (-0.004%))
testFloorFromChainlinkPremiumOraclePriceNotRecentEnough() (gas: -27 (-0.004%))
testFloorFromChainlinkPremiumTakerBidAmountNotOne() (gas: -27 (-0.004%))
testFloorFromChainlinkPremiumTakerBidAmountNotOne() (gas: -27 (-0.004%))
testTakerBidTooLow() (gas: -27 (-0.004%))
testItemIdsMismatch() (gas: -27 (-0.004%))
testFloorFromChainlinkDiscountOraclePriceNotRecentEnough() (gas: -27 (-0.004%))
testFloorFromChainlinkDiscountOraclePriceNotRecentEnough() (gas: -27 (-0.004%))
testFloorFromChainlinkDiscountMakerBidAmountNotOne() (gas: -27 (-0.004%))
testFloorFromChainlinkDiscountMakerBidAmountNotOne() (gas: -27 (-0.004%))
testFloorFromChainlinkDiscountTakerAskZeroAmount() (gas: -27 (-0.004%))
testFloorFromChainlinkDiscountTakerAskZeroAmount() (gas: -27 (-0.004%))
testFloorFromChainlinkPremiumMakerAskAmountNotOne() (gas: -27 (-0.004%))
testFloorFromChainlinkPremiumMakerAskAmountNotOne() (gas: -27 (-0.004%))
testFloorFromChainlinkPremiumPriceFeedNotAvailable() (gas: -27 (-0.004%))
testFloorFromChainlinkPremiumPriceFeedNotAvailable() (gas: -27 (-0.004%))
testZeroAmount() (gas: -27 (-0.004%))
testOraclePriceNotRecentEnough() (gas: -27 (-0.004%))
testFloorFromChainlinkDiscountTakerAskAmountsLengthNotOne() (gas: -27 (-0.004%))
testFloorFromChainlinkDiscountTakerAskItemIdsLengthNotOne() (gas: -27 (-0.004%))
testFloorFromChainlinkDiscountTakerAskAmountsLengthNotOne() (gas: -27 (-0.004%))
testFloorFromChainlinkDiscountTakerAskItemIdsLengthNotOne() (gas: -27 (-0.004%))
testFloorFromChainlinkDiscountPriceFeedNotAvailable() (gas: -27 (-0.004%))
testFloorFromChainlinkDiscountPriceFeedNotAvailable() (gas: -27 (-0.004%))
testFloorFromChainlinkDiscountBasisPointsDesiredDiscountBasisPointsGreaterThan10000() (gas: -27 (-0.004%))
testFloorFromChainlinkPremiumMakerAskAmountsLengthNotOne() (gas: -27 (-0.004%))
testFloorFromChainlinkPremiumMakerAskAmountsLengthNotOne() (gas: -27 (-0.004%))
testFloorFromChainlinkPremiumMakerAskItemIdsLengthNotOne() (gas: -27 (-0.004%))
testFloorFromChainlinkPremiumMakerAskItemIdsLengthNotOne() (gas: -27 (-0.004%))
testFloorFromChainlinkDiscountMakerBidAmountsLengthNotOne() (gas: -27 (-0.004%))
testFloorFromChainlinkDiscountMakerBidAmountsLengthNotOne() (gas: -27 (-0.004%))
testZeroItemIdsLength() (gas: -27 (-0.006%))
testFloorFromChainlinkPremiumChainlinkPriceLessThanOrEqualToZero() (gas: -54 (-0.006%))
testFloorFromChainlinkPremiumChainlinkPriceLessThanOrEqualToZero() (gas: -54 (-0.006%))
testFloorFromChainlinkDiscountChainlinkPriceLessThanOrEqualToZero() (gas: -54 (-0.006%))
testFloorFromChainlinkDiscountChainlinkPriceLessThanOrEqualToZero() (gas: -54 (-0.006%))
testUSDDynamicAskInvalidChainlinkPrice() (gas: -54 (-0.007%))
testFloorFromChainlinkDiscountFixedAmountDesiredDiscountedAmountGreaterThanOrEqualToFloorPrice() (gas: -54 (-0.007%))
testCannotValidateOrderIfWrongTimestamps() (gas: -78 (-0.013%))
testCannotValidateOrderIfWrongFormat() (gas: -316 (-0.023%))
testCreatorRoyaltiesRevertIfFeeHigherThanLimit() (gas: -324 (-0.023%))
testTakerAskCollectionOrderWithMerkleTreeERC721() (gas: -1839 (-0.063%))
testCannotExecuteAnotherOrderAtNonceIfExecutionIsInProgress() (gas: -1838 (-0.083%))
testTokenIdsRangeERC721() (gas: -1839 (-0.084%))
testTakerAskForceAmountOneIfERC721() (gas: -1839 (-0.085%))
testDutchAuction(uint256) (gas: -1824 (-0.088%))
testTokenIdsRangeERC1155() (gas: -1839 (-0.088%))
testTakerAskCollectionOrderERC721(uint256) (gas: -1838 (-0.089%))
testCreatorRoyaltiesGetPaidForERC2981WithBundles() (gas: -1944 (-0.112%))
testTakerBidERC721BundleNoRoyalties() (gas: -1824 (-0.124%))
testTakerAskERC721BundleNoRoyalties() (gas: -1839 (-0.124%))
testCreatorRoyaltiesGetPaidForRoyaltyFeeManagerWithBundles() (gas: -1944 (-0.124%))
testTakerAskERC721BundleWithRoyaltiesFromRegistry() (gas: -1987 (-0.127%))
testTakerBidERC721BundleWithRoyaltiesFromRegistry() (gas: -1972 (-0.127%))
testMultiFill() (gas: -3677 (-0.141%))
testTakerAskERC721WithAffiliateButWithoutRoyalty() (gas: -1838 (-0.171%))
testTakerBidERC721WithAffiliateButWithoutRoyalty() (gas: -1823 (-0.171%))
testCreatorRoyaltiesGetPaidForRoyaltyFeeManager() (gas: -1943 (-0.184%))
testCannotExecuteAnOrderTwice() (gas: -1986 (-0.187%))
testCreatorRoyaltiesGetPaidForERC2981() (gas: -1943 (-0.188%))
testTakerAskERC721WithRoyaltiesFromRegistry() (gas: -1986 (-0.189%))
testTakerBidERC721WithRoyaltiesFromRegistry() (gas: -1971 (-0.190%))
testFloorFromChainlinkPremiumFixedAmountDesiredSalePriceLessThanMinPrice() (gas: -1824 (-0.213%))
testFloorFromChainlinkPremiumFixedAmountDesiredSalePriceGreaterThanMinPrice() (gas: -1824 (-0.214%))
testFloorFromChainlinkPremiumFixedAmountDesiredSalePriceEqualToMinPrice() (gas: -1824 (-0.214%))
testFloorFromChainlinkDiscountFixedAmountDesiredDiscountedPriceGreaterThanOrEqualToMaxPrice() (gas: -1839 (-0.219%))
testFloorFromChainlinkDiscountFixedAmountDesiredDiscountedPriceLessThanMaxPrice() (gas: -1839 (-0.219%))
testFloorFromChainlinkDiscountBasisPointsDesiredDiscountedPriceGreaterThanOrEqualToMaxPrice() (gas: -1839 (-0.220%))
testFloorFromChainlinkDiscountBasisPointsDesiredDiscountedPriceLessThanMaxPrice() (gas: -1839 (-0.220%))
testUSDDynamicAskUSDValueLessThanMinAcceptedEthValue() (gas: -1824 (-0.221%))
testUSDDynamicAskUSDValueLessThanOneETH() (gas: -1824 (-0.221%))
testUSDDynamicAskUSDValueGreaterThanOrEqualToMinAcceptedEthValue() (gas: -1824 (-0.221%))
testUSDDynamicAskBidderOverpaid() (gas: -1824 (-0.227%))
testFloorFromChainlinkPremiumBasisPointsDesiredSalePriceLessThanMinPrice() (gas: -1824 (-0.432%))
testFloorFromChainlinkPremiumBasisPointsDesiredSalePriceGreaterThanMinPrice() (gas: -1824 (-0.434%))
testFloorFromChainlinkPremiumBasisPointsDesiredSalePriceEqualToMinPrice() (gas: -1824 (-0.434%))
testThreeTakerBidsERC721() (gas: -5463 (-0.660%))
testThreeTakerBidsERC721OneFails() (gas: -8352 (-0.766%))
testMultipleTakerBidsERC721WithAffiliateButWithoutRoyalty() (gas: -13291 (-0.868%))
Overall gas change: -100505 (-9.027%)
```