### PR TITLE
perf: SignatureParameters does not need a variable

### DIFF
--- a/contracts/LooksRareProtocol.sol
+++ b/contracts/LooksRareProtocol.sol
@@ -309,15 +309,13 @@ contract LooksRareProtocol is
             _transferNFT(makerBid.collection, makerBid.assetType, msg.sender, signer, itemIds, amounts);
         }
 
-        SignatureParameters memory signatureParameters = SignatureParameters({
-            orderHash: orderHash,
-            orderNonce: makerBid.orderNonce,
-            isNonceInvalidated: isNonceInvalidated,
-            signer: signer
-        });
-
         emit TakerAsk(
-            signatureParameters,
+            SignatureParameters({
+                orderHash: orderHash,
+                orderNonce: makerBid.orderNonce,
+                isNonceInvalidated: isNonceInvalidated,
+                signer: signer
+            }),
             msg.sender,
             makerBid.strategyId,
             makerBid.currency,
@@ -397,15 +395,13 @@ contract LooksRareProtocol is
             }
         }
 
-        SignatureParameters memory signatureParameters = SignatureParameters({
-            orderHash: orderHash,
-            orderNonce: makerAsk.orderNonce,
-            isNonceInvalidated: isNonceInvalidated,
-            signer: signer
-        });
-
         emit TakerBid(
-            signatureParameters,
+            SignatureParameters({
+                orderHash: orderHash,
+                orderNonce: makerAsk.orderNonce,
+                isNonceInvalidated: isNonceInvalidated,
+                signer: signer
+            }),
             sender,
             makerAsk.strategyId,
             makerAsk.currency,


### PR DESCRIPTION
1. Contract size down from 28506 to 28491
2.

```
testTakerBidMultipleOrdersSignedERC721() (gas: -13 (-0.000%))
testTakerAskMultipleOrdersSignedERC721() (gas: -22 (-0.000%))
testDutchAuction(uint256) (gas: -13 (-0.001%))
testTakerAskCollectionOrderWithMerkleTreeERC721() (gas: -22 (-0.001%))
testTakerBidERC721BundleWithRoyaltiesFromRegistry() (gas: -13 (-0.001%))
testTakerBidERC721BundleNoRoyalties() (gas: -13 (-0.001%))
testCannotExecuteAnotherOrderAtNonceIfExecutionIsInProgress() (gas: -22 (-0.001%))
testTokenIdsRangeERC721() (gas: -22 (-0.001%))
testTakerAskForceAmountOneIfERC721() (gas: -22 (-0.001%))
testTokenIdsRangeERC1155() (gas: -22 (-0.001%))
testTakerAskCollectionOrderERC721(uint256) (gas: -22 (-0.001%))
testTakerBidERC721WithAffiliateButWithoutRoyalty() (gas: -13 (-0.001%))
testTakerBidERC721WithRoyaltiesFromRegistry() (gas: -13 (-0.001%))
testCreatorRoyaltiesGetPaidForERC2981WithBundles() (gas: -22 (-0.001%))
testCreatorRoyaltiesGetPaidForRoyaltyFeeManagerWithBundles() (gas: -22 (-0.001%))
testTakerAskERC721BundleWithRoyaltiesFromRegistry() (gas: -22 (-0.001%))
testTakerAskERC721BundleNoRoyalties() (gas: -22 (-0.001%))
testFloorFromChainlinkPremiumFixedAmountDesiredSalePriceLessThanMinPrice() (gas: -13 (-0.002%))
testFloorFromChainlinkPremiumFixedAmountDesiredSalePriceGreaterThanMinPrice() (gas: -13 (-0.002%))
testFloorFromChainlinkPremiumFixedAmountDesiredSalePriceEqualToMinPrice() (gas: -13 (-0.002%))
testUSDDynamicAskUSDValueLessThanMinAcceptedEthValue() (gas: -13 (-0.002%))
testUSDDynamicAskUSDValueLessThanOneETH() (gas: -13 (-0.002%))
testUSDDynamicAskUSDValueGreaterThanOrEqualToMinAcceptedEthValue() (gas: -13 (-0.002%))
testUSDDynamicAskBidderOverpaid() (gas: -13 (-0.002%))
testMultiFill() (gas: -44 (-0.002%))
testTakerAskERC721WithAffiliateButWithoutRoyalty() (gas: -22 (-0.002%))
testCannotExecuteAnOrderTwice() (gas: -22 (-0.002%))
testCreatorRoyaltiesGetPaidForRoyaltyFeeManager() (gas: -22 (-0.002%))
testTakerAskERC721WithRoyaltiesFromRegistry() (gas: -22 (-0.002%))
testCreatorRoyaltiesGetPaidForERC2981() (gas: -22 (-0.002%))
testFloorFromChainlinkDiscountFixedAmountDesiredDiscountedPriceGreaterThanOrEqualToMaxPrice() (gas: -22 (-0.003%))
testFloorFromChainlinkDiscountFixedAmountDesiredDiscountedPriceLessThanMaxPrice() (gas: -22 (-0.003%))
testFloorFromChainlinkDiscountBasisPointsDesiredDiscountedPriceGreaterThanOrEqualToMaxPrice() (gas: -22 (-0.003%))
testFloorFromChainlinkDiscountBasisPointsDesiredDiscountedPriceLessThanMaxPrice() (gas: -22 (-0.003%))
testFloorFromChainlinkPremiumBasisPointsDesiredSalePriceLessThanMinPrice() (gas: -13 (-0.003%))
testFloorFromChainlinkPremiumBasisPointsDesiredSalePriceGreaterThanMinPrice() (gas: -13 (-0.003%))
testFloorFromChainlinkPremiumBasisPointsDesiredSalePriceEqualToMinPrice() (gas: -13 (-0.003%))
testThreeTakerBidsERC721() (gas: -39 (-0.005%))
testThreeTakerBidsERC721OneFails() (gas: -52 (-0.005%))
testMultipleTakerBidsERC721WithAffiliateButWithoutRoyalty() (gas: -91 (-0.006%))
Overall gas change: -874 (-0.074%)
```