### PR TITLE
perf: Transfer NFT optimization

### DIFF
--- a/contracts/TransferSelectorNFT.sol
+++ b/contracts/TransferSelectorNFT.sol
@@ -63,13 +63,13 @@ contract TransferSelectorNFT is ITransferSelectorNFT, OwnableTwoSteps {
         uint256[] memory itemIds,
         uint256[] memory amounts
     ) internal {
-        ManagerSelector memory managerSelector = managerSelectorOfAssetType[assetType];
+        address transferManager = managerSelectorOfAssetType[assetType].transferManager;
+        bytes4 selector = managerSelectorOfAssetType[assetType].selector;
 
-        if (managerSelector.transferManager == address(0) || managerSelector.selector == bytes4(0))
-            revert NoTransferManagerForAssetType(assetType);
+        if (transferManager == address(0) || selector == bytes4(0)) revert NoTransferManagerForAssetType(assetType);
 
-        (bool status, ) = managerSelector.transferManager.call(
-            abi.encodeWithSelector(managerSelector.selector, collection, sender, recipient, itemIds, amounts)
+        (bool status, ) = transferManager.call(
+            abi.encodeWithSelector(selector, collection, sender, recipient, itemIds, amounts)
         );
 
         if (!status) revert NFTTransferFail(collection, assetType);


### PR DESCRIPTION
1. Contract size down from 28506 to 28440
2.

```
testTakerBidMultipleOrdersSignedERC721() (gas: -101 (-0.000%))
testTakerAskMultipleOrdersSignedERC721() (gas: -101 (-0.000%))
testTakerAskCollectionOrderWithMerkleTreeERC721() (gas: -101 (-0.003%))
testCannotExecuteAnotherOrderAtNonceIfExecutionIsInProgress() (gas: -101 (-0.005%))
testTokenIdsRangeERC721() (gas: -101 (-0.005%))
testTakerAskForceAmountOneIfERC721() (gas: -101 (-0.005%))
testTokenIdsRangeERC1155() (gas: -101 (-0.005%))
testTakerAskCollectionOrderERC721(uint256) (gas: -101 (-0.005%))
testDutchAuction(uint256) (gas: -102 (-0.005%))
testCreatorRoyaltiesGetPaidForERC2981WithBundles() (gas: -102 (-0.006%))
testTakerBidERC721BundleWithRoyaltiesFromRegistry() (gas: -101 (-0.007%))
testCreatorRoyaltiesGetPaidForRoyaltyFeeManagerWithBundles() (gas: -102 (-0.007%))
testTakerAskERC721BundleWithRoyaltiesFromRegistry() (gas: -102 (-0.007%))
testTakerBidERC721BundleNoRoyalties() (gas: -101 (-0.007%))
testTakerAskERC721BundleNoRoyalties() (gas: -102 (-0.007%))
testMultiFill() (gas: -203 (-0.008%))
testTakerAskERC721WithAffiliateButWithoutRoyalty() (gas: -101 (-0.009%))
testTakerBidERC721WithAffiliateButWithoutRoyalty() (gas: -101 (-0.009%))
testCannotExecuteAnOrderTwice() (gas: -101 (-0.010%))
testCreatorRoyaltiesGetPaidForRoyaltyFeeManager() (gas: -101 (-0.010%))
testTakerAskERC721WithRoyaltiesFromRegistry() (gas: -101 (-0.010%))
testTakerBidERC721WithRoyaltiesFromRegistry() (gas: -101 (-0.010%))
testCreatorRoyaltiesGetPaidForERC2981() (gas: -101 (-0.010%))
testFloorFromChainlinkPremiumFixedAmountDesiredSalePriceLessThanMinPrice() (gas: -102 (-0.012%))
testFloorFromChainlinkPremiumFixedAmountDesiredSalePriceGreaterThanMinPrice() (gas: -102 (-0.012%))
testFloorFromChainlinkPremiumFixedAmountDesiredSalePriceEqualToMinPrice() (gas: -102 (-0.012%))
testFloorFromChainlinkDiscountFixedAmountDesiredDiscountedPriceGreaterThanOrEqualToMaxPrice() (gas: -102 (-0.012%))
testFloorFromChainlinkDiscountFixedAmountDesiredDiscountedPriceLessThanMaxPrice() (gas: -102 (-0.012%))
testFloorFromChainlinkDiscountBasisPointsDesiredDiscountedPriceGreaterThanOrEqualToMaxPrice() (gas: -102 (-0.012%))
testFloorFromChainlinkDiscountBasisPointsDesiredDiscountedPriceLessThanMaxPrice() (gas: -102 (-0.012%))
testUSDDynamicAskUSDValueLessThanMinAcceptedEthValue() (gas: -102 (-0.012%))
testUSDDynamicAskUSDValueLessThanOneETH() (gas: -102 (-0.012%))
testUSDDynamicAskUSDValueGreaterThanOrEqualToMinAcceptedEthValue() (gas: -102 (-0.012%))
testUSDDynamicAskBidderOverpaid() (gas: -101 (-0.013%))
testFloorFromChainlinkPremiumBasisPointsDesiredSalePriceLessThanMinPrice() (gas: -102 (-0.024%))
testFloorFromChainlinkPremiumBasisPointsDesiredSalePriceGreaterThanMinPrice() (gas: -102 (-0.024%))
testFloorFromChainlinkPremiumBasisPointsDesiredSalePriceEqualToMinPrice() (gas: -102 (-0.024%))
testThreeTakerBidsERC721() (gas: -300 (-0.036%))
testMultipleTakerBidsERC721WithAffiliateButWithoutRoyalty() (gas: -803 (-0.052%))
testThreeTakerBidsERC721OneFails() (gas: -612 (-0.056%))
Overall gas change: -5572 (-0.498%)
```