### PR TITLE
test: CreatorFeeManagerWithRebates

### DIFF
--- a/test/foundry/CreatorFeeManagerWithRebates.t.sol
+++ b/test/foundry/CreatorFeeManagerWithRebates.t.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+import {IERC721} from "@looksrare/contracts-libs/contracts/interfaces/generic/IERC721.sol";
+
 import {OrderStructs} from "../../contracts/libraries/OrderStructs.sol";
 import {ProtocolBase} from "./ProtocolBase.t.sol";
 
@@ -8,7 +10,7 @@ import {IExecutionManager} from "../../contracts/interfaces/IExecutionManager.so
 import {ICreatorFeeManager} from "../../contracts/interfaces/ICreatorFeeManager.sol";
 
 contract CreatorFeeManagerWithRebatesTest is ProtocolBase {
-    function _setUpRoyaltiesRegistry(uint256 fee) internal {
+    function _setUpRoyaltiesRegistry(uint256 fee) private {
         vm.prank(_owner);
         royaltyFeeRegistry.updateRoyaltyInfoForCollection(
             address(mockERC721),
@@ -18,14 +20,28 @@ contract CreatorFeeManagerWithRebatesTest is ProtocolBase {
         );
     }
 
-    function testCreatorRebatesGetPaidForRoyaltyFeeManager() public {
+    function _testCreatorFeeRebatesArePaid(address erc721) private {
         _setUpUsers();
 
-        // Adjust royalties
-        _setUpRoyaltiesRegistry(_standardRoyaltyFee);
+        // Parameters
+        price = 1 ether;
+        uint256 itemId = 42;
 
-        price = 1 ether; // Fixed price of sale
-        uint256 itemId = 0; // TokenId
+        if (erc721 == address(mockERC721)) {
+            // Adjust royalties
+            _setUpRoyaltiesRegistry(_standardRoyaltyFee);
+            // Mint asset
+            mockERC721.mint(takerUser, itemId);
+        } else if (erc721 == address(mockERC721WithRoyalties)) {
+            // Adjust ERC721 with royalties
+            mockERC721WithRoyalties.addCustomRoyaltyInformationForTokenId(
+                itemId,
+                _royaltyRecipient,
+                _standardRoyaltyFee
+            );
+            // Mint asset
+            mockERC721WithRoyalties.mint(takerUser, itemId);
+        }
 
         // Prepare the order hash
         makerBid = _createSingleItemMakerBidOrder(
@@ -34,7 +50,7 @@ contract CreatorFeeManagerWithRebatesTest is ProtocolBase {
             0, // strategyId (Standard sale for fixed price)
             0, // assetType ERC721,
             0, // orderNonce
-            address(mockERC721),
+            erc721,
             address(weth),
             makerUser,
             price,
@@ -43,9 +59,6 @@ contract CreatorFeeManagerWithRebatesTest is ProtocolBase {
 
         // Sign order
         signature = _signMakerBid(makerBid, makerUserPK);
-
-        // Mint asset
-        mockERC721.mint(takerUser, itemId);
 
         // Prepare the taker ask
         takerAsk = OrderStructs.TakerAsk(
@@ -60,8 +73,8 @@ contract CreatorFeeManagerWithRebatesTest is ProtocolBase {
         vm.prank(takerUser);
         looksRareProtocol.executeTakerAsk(takerAsk, makerBid, signature, _emptyMerkleTree, _emptyAffiliate);
 
-        // Taker user has received the asset
-        assertEq(mockERC721.ownerOf(itemId), makerUser);
+        // Verify ownership is transferred
+        assertEq(IERC721(erc721).ownerOf(itemId), makerUser);
         // Maker bid user pays the whole price
         assertEq(weth.balanceOf(makerUser), _initialWETHBalanceUser - price);
         // Owner receives 1.5% of the whole price
@@ -77,84 +90,39 @@ contract CreatorFeeManagerWithRebatesTest is ProtocolBase {
         assertEq(looksRareProtocol.userOrderNonce(makerUser, makerBid.orderNonce), MAGIC_VALUE_NONCE_EXECUTED);
     }
 
-    function testCreatorRoyaltiesGetPaidForERC2981() public {
-        uint256 itemId = 0; // TokenId
-        price = 1 ether; // Fixed price of sale
-
-        _setUpUsers();
-
-        // Adjust ERC721 with royalties
-        mockERC721WithRoyalties.addCustomRoyaltyInformationForTokenId(itemId, _royaltyRecipient, _standardRoyaltyFee);
-
-        // Prepare the order hash
-        makerBid = _createSingleItemMakerBidOrder(
-            0, // askNonce
-            0, // subsetNonce
-            0, // strategyId (Standard sale for fixed price)
-            0, // assetType ERC721,
-            0, // orderNonce
-            address(mockERC721WithRoyalties),
-            address(weth),
-            makerUser,
-            price,
-            itemId
-        );
-
-        // Sign order
-        signature = _signMakerBid(makerBid, makerUserPK);
-
-        // Mint asset
-        mockERC721WithRoyalties.mint(takerUser, itemId);
-
-        // Prepare the taker ask
-        takerAsk = OrderStructs.TakerAsk(
-            takerUser,
-            makerBid.maxPrice,
-            makerBid.itemIds,
-            makerBid.amounts,
-            abi.encode()
-        );
-
-        // Execute taker ask transaction
-        vm.prank(takerUser);
-        looksRareProtocol.executeTakerAsk(takerAsk, makerBid, signature, _emptyMerkleTree, _emptyAffiliate);
-
-        // Taker user has received the asset
-        assertEq(mockERC721WithRoyalties.ownerOf(itemId), makerUser);
-        // Owner receives 1.5% of the whole price
-        assertEq(weth.balanceOf(_owner), _initialWETHBalanceOwner + (price * _standardProtocolFee) / 10000);
-        // Maker bid user pays the whole price
-        assertEq(weth.balanceOf(makerUser), _initialWETHBalanceUser - price);
-        // Taker ask user receives 98% of the whole price
-        assertEq(weth.balanceOf(takerUser), _initialWETHBalanceUser + (price * 9800) / 10000);
-        // Royalty recipient receives 0.5% of the whole price
-        assertEq(
-            weth.balanceOf(_royaltyRecipient),
-            _initialWETHBalanceRoyaltyRecipient + (price * _standardRoyaltyFee) / 10000
-        );
-        // Verify the nonce is marked as executed
-        assertEq(looksRareProtocol.userOrderNonce(makerUser, makerBid.orderNonce), MAGIC_VALUE_NONCE_EXECUTED);
-    }
-
-    function testCreatorRoyaltiesGetPaidForRoyaltyFeeManagerWithBundles() public {
+    function _testCreatorFeeRebatesArePaidForBundles(address erc721) private {
         _setUpUsers();
         _setUpRoyaltiesRegistry(_standardRoyaltyFee);
 
+        // Parameters
         uint256 numberItemsInBundle = 5;
 
-        (makerBid, takerAsk) = _createMockMakerBidAndTakerAskWithBundle(
-            address(mockERC721),
-            address(weth),
-            numberItemsInBundle
-        );
+        // Create order
+        (makerBid, takerAsk) = _createMockMakerBidAndTakerAskWithBundle(erc721, address(weth), numberItemsInBundle);
 
+        // Adjust price
         price = makerBid.maxPrice;
+
+        if (erc721 == address(mockERC721)) {
+            // Adjust royalties
+            _setUpRoyaltiesRegistry(_standardRoyaltyFee);
+            // Mint the items
+            mockERC721.batchMint(takerUser, makerBid.itemIds);
+        } else if (erc721 == address(mockERC721WithRoyalties)) {
+            // Adjust ERC721 with royalties
+            for (uint256 i; i < makerBid.itemIds.length; i++) {
+                mockERC721WithRoyalties.addCustomRoyaltyInformationForTokenId(
+                    makerBid.itemIds[i],
+                    _royaltyRecipient,
+                    _standardRoyaltyFee
+                );
+            }
+            // Mint the items
+            mockERC721WithRoyalties.batchMint(takerUser, makerBid.itemIds);
+        }
 
         // Sign the order
         signature = _signMakerBid(makerBid, makerUserPK);
-
-        // Mint the items
-        mockERC721.batchMint(takerUser, makerBid.itemIds);
 
         // Taker user actions
         vm.prank(takerUser);
@@ -162,9 +130,10 @@ contract CreatorFeeManagerWithRebatesTest is ProtocolBase {
         // Execute taker ask transaction
         looksRareProtocol.executeTakerAsk(takerAsk, makerBid, signature, _emptyMerkleTree, _emptyAffiliate);
 
+        // Verify ownership is transferred
         for (uint256 i; i < makerBid.itemIds.length; i++) {
             // Maker user has received all the assets in the bundle
-            assertEq(mockERC721.ownerOf(makerBid.itemIds[i]), makerUser);
+            assertEq(IERC721(erc721).ownerOf(makerBid.itemIds[i]), makerUser);
         }
 
         // Maker bid user pays the whole price
@@ -182,54 +151,20 @@ contract CreatorFeeManagerWithRebatesTest is ProtocolBase {
         assertEq(looksRareProtocol.userOrderNonce(makerUser, makerBid.orderNonce), MAGIC_VALUE_NONCE_EXECUTED);
     }
 
+    function testCreatorRebatesArePaidForRoyaltyFeeManager() public {
+        _testCreatorFeeRebatesArePaid(address(mockERC721));
+    }
+
+    function testCreatorRebatesArePaidForERC2981() public {
+        _testCreatorFeeRebatesArePaid(address(mockERC721WithRoyalties));
+    }
+
+    function testCreatorRebatesArePaidForRoyaltyFeeManagerWithBundles() public {
+        _testCreatorFeeRebatesArePaidForBundles(address(mockERC721));
+    }
+
     function testCreatorRoyaltiesGetPaidForERC2981WithBundles() public {
-        _setUpUsers();
-
-        uint256 numberItemsInBundle = 5;
-
-        (makerBid, takerAsk) = _createMockMakerBidAndTakerAskWithBundle(
-            address(mockERC721WithRoyalties),
-            address(weth),
-            numberItemsInBundle
-        );
-
-        price = makerBid.maxPrice;
-
-        // Sign the order
-        signature = _signMakerBid(makerBid, makerUserPK);
-
-        // Mint the items
-        mockERC721WithRoyalties.batchMint(takerUser, makerBid.itemIds);
-
-        // Adjust ERC721 with royalties
-        for (uint256 i; i < makerBid.itemIds.length; i++) {
-            mockERC721WithRoyalties.addCustomRoyaltyInformationForTokenId(
-                makerBid.itemIds[i],
-                _royaltyRecipient,
-                _standardRoyaltyFee
-            );
-        }
-
-        // Taker user actions
-        vm.prank(takerUser);
-
-        // Execute taker ask transaction
-        looksRareProtocol.executeTakerAsk(takerAsk, makerBid, signature, _emptyMerkleTree, _emptyAffiliate);
-
-        // Maker bid user pays the whole price
-        assertEq(weth.balanceOf(makerUser), _initialWETHBalanceUser - price);
-
-        // Royalty recipient receives royalties
-        assertEq(
-            weth.balanceOf(_royaltyRecipient),
-            _initialWETHBalanceRoyaltyRecipient + (price * _standardRoyaltyFee) / 10000
-        );
-        // Owner receives protocol fee
-        assertEq(weth.balanceOf(_owner), _initialWETHBalanceOwner + (price * _standardProtocolFee) / 10000);
-        // Taker ask user receives 98% of the whole price
-        assertEq(weth.balanceOf(takerUser), _initialWETHBalanceUser + (price * 9800) / 10000);
-        // Verify the nonce is marked as executed
-        assertEq(looksRareProtocol.userOrderNonce(makerUser, makerBid.orderNonce), MAGIC_VALUE_NONCE_EXECUTED);
+        _testCreatorFeeRebatesArePaidForBundles(address(mockERC721WithRoyalties));
     }
 
     function testCreatorRoyaltiesRevertForEIP2981WithBundlesIfInfoDiffer() public {
@@ -252,7 +187,7 @@ contract CreatorFeeManagerWithRebatesTest is ProtocolBase {
         mockERC721WithRoyalties.batchMint(takerUser, makerBid.itemIds);
 
         /**
-         * 1. Different recipient
+         * Different recipient
          */
 
         // Adjust ERC721 with royalties
@@ -271,7 +206,6 @@ contract CreatorFeeManagerWithRebatesTest is ProtocolBase {
                 address(mockERC721WithRoyalties)
             )
         );
-
         looksRareProtocol.executeTakerAsk(takerAsk, makerBid, signature, _emptyMerkleTree, _emptyAffiliate);
     }
 }


### PR DESCRIPTION
This PR contains tests for `CreatorFeeManagerWithRebates`, the alternative implementation for creator fees suggested by the new product requirements.