### PR TITLE
perf: Extract protocol fee calculation

### DIFF
--- a/contracts/ExecutionManager.sol
+++ b/contracts/ExecutionManager.sol
@@ -97,13 +97,7 @@ contract ExecutionManager is InheritedStrategies, NonceManager, StrategyManager,
             if (recipients[1] == address(0) || fees[1] == 0) {
                 fees[0] = minTotalFee;
             } else {
-                uint256 standardProtocolFee = (price * strategyInfo[makerBid.strategyId].standardProtocolFee) / 10_000;
-
-                if (fees[1] + standardProtocolFee > minTotalFee) {
-                    fees[0] = standardProtocolFee;
-                } else {
-                    fees[0] = minTotalFee - fees[1];
-                }
+                fees[0] = _calculateProtocolFee(price, makerBid.strategyId, fees[1], minTotalFee);
             }
 
             recipients[0] = protocolFeeRecipient;
@@ -148,13 +142,7 @@ contract ExecutionManager is InheritedStrategies, NonceManager, StrategyManager,
             if (recipients[1] == address(0) || fees[1] == 0) {
                 fees[0] = minTotalFee;
             } else {
-                uint256 standardProtocolFee = (price * strategyInfo[makerAsk.strategyId].standardProtocolFee) / 10_000;
-
-                if (fees[1] + standardProtocolFee > minTotalFee) {
-                    fees[0] = standardProtocolFee;
-                } else {
-                    fees[0] = minTotalFee - fees[1];
-                }
+                fees[0] = _calculateProtocolFee(price, makerAsk.strategyId, fees[1], minTotalFee);
             }
 
             recipients[0] = protocolFeeRecipient;
@@ -246,5 +234,20 @@ contract ExecutionManager is InheritedStrategies, NonceManager, StrategyManager,
      */
     function _verifyOrderTimestampValidity(uint256 startTime, uint256 endTime) internal view {
         if (startTime > block.timestamp || endTime < block.timestamp) revert OutsideOfTimeRange();
+    }
+
+    function _calculateProtocolFee(
+        uint256 price,
+        uint16 strategyId,
+        uint256 creatorFee,
+        uint256 minTotalFee
+    ) private returns (uint256 protocolFee) {
+        uint256 standardProtocolFee = (price * strategyInfo[strategyId].standardProtocolFee) / 10_000;
+
+        if (creatorFee + standardProtocolFee > minTotalFee) {
+            protocolFee = standardProtocolFee;
+        } else {
+            protocolFee = minTotalFee - creatorFee;
+        }
     }
 }


### PR DESCRIPTION
```
testTakerAskERC721BundleWithRoyaltiesFromRegistry() (gas: 16 (0.001%))
testTakerBidERC721BundleWithRoyaltiesFromRegistry() (gas: 16 (0.001%))
testCannotExecuteAnOrderTwice() (gas: 16 (0.002%))
testTakerAskERC721WithRoyaltiesFromRegistry() (gas: 16 (0.002%))
testTakerBidERC721WithRoyaltiesFromRegistry() (gas: 16 (0.002%))
testCreatorRoyaltiesGetPaidForERC2981WithBundles() (gas: 32 (0.002%))
testCreatorRoyaltiesGetPaidForRoyaltyFeeManagerWithBundles() (gas: 32 (0.002%))
testCreatorRoyaltiesGetPaidForRoyaltyFeeManager() (gas: 32 (0.003%))
testCreatorRoyaltiesGetPaidForERC2981() (gas: 32 (0.003%))
Overall gas change: 208 (0.017%)
```

More gas, but contract size down by 111