### PR TITLE
perf: Use XOR to check equality

### DIFF
--- a/contracts/InheritedStrategies.sol
+++ b/contracts/InheritedStrategies.sol
@@ -78,9 +78,11 @@ contract InheritedStrategies {
     ) private pure {
         if (
             amountsLength == 0 ||
-            itemIdsLength != amountsLength ||
-            counterpartyItemIdsLength != amountsLength ||
-            counterpartyAmountsLength != amountsLength ||
+            // If A == B, then A XOR B == 0. So if all 4 are equal, it should be 0 | 0 | 0 == 0
+            ((amountsLength ^ itemIdsLength) |
+                (counterpartyItemIdsLength ^ counterpartyAmountsLength) |
+                (amountsLength ^ counterpartyItemIdsLength)) !=
+            0 ||
             price != counterpartyPrice
         ) revert OrderInvalid();
     }


### PR DESCRIPTION
24698 -> 24685

```
testTakerBidMultipleOrdersSignedERC721() (gas: -35 (-0.000%))
testTakerAskMultipleOrdersSignedERC721() (gas: -35 (-0.000%))
testCreatorRoyaltiesGetPaidForERC2981WithBundles() (gas: -35 (-0.002%))
testCreatorRoyaltiesGetPaidForRoyaltyFeeManagerWithBundles() (gas: -35 (-0.002%))
testTakerAskERC721BundleWithRoyaltiesFromRegistry() (gas: -35 (-0.002%))
testTakerBidERC721BundleWithRoyaltiesFromRegistry() (gas: -35 (-0.002%))
testTakerAskERC721BundleNoRoyalties() (gas: -35 (-0.002%))
testTakerBidERC721BundleNoRoyalties() (gas: -35 (-0.002%))
testTakerAskERC721WithAffiliateButWithoutRoyalty() (gas: -35 (-0.003%))
testTakerBidERC721WithAffiliateButWithoutRoyalty() (gas: -35 (-0.003%))
testCannotExecuteAnOrderTwice() (gas: -35 (-0.003%))
testCreatorRoyaltiesGetPaidForRoyaltyFeeManager() (gas: -35 (-0.003%))
testTakerAskERC721WithRoyaltiesFromRegistry() (gas: -35 (-0.003%))
testTakerBidERC721WithRoyaltiesFromRegistry() (gas: -35 (-0.003%))
testCreatorRoyaltiesGetPaidForERC2981() (gas: -35 (-0.003%))
testCreatorRoyaltiesRevertForEIP2981WithBundlesIfInfoDiffer() (gas: -70 (-0.004%))
testCreatorRoyaltiesRevertIfFeeHigherThanLimit() (gas: -70 (-0.005%))
testThreeTakerBidsERC721() (gas: -105 (-0.013%))
testMultipleTakerBidsERC721WithAffiliateButWithoutRoyalty() (gas: -280 (-0.018%))
testThreeTakerBidsERC721OneFails() (gas: -210 (-0.019%))
testCannotValidateOrderIfWrongFormat() (gas: -280 (-0.021%))
Overall gas change: -1540 (-0.117%)
```