### PR TITLE
perf: Skip loop

### DIFF
--- a/contracts/LooksRareProtocol.sol
+++ b/contracts/LooksRareProtocol.sol
@@ -494,15 +494,14 @@ contract LooksRareProtocol is
         address currency,
         address sender
     ) private {
-        // It starts at 1 since the protocol fee is transferred at the very end
-        for (uint256 i = 1; i < 3; ) {
-            if (recipients[i] != address(0)) {
-                if (fees[i] != 0) {
-                    _transferFungibleTokens(currency, sender, recipients[i], fees[i]);
-                }
+        if (recipients[1] != address(0)) {
+            if (fees[1] != 0) {
+                _transferFungibleTokens(currency, sender, recipients[1], fees[1]);
             }
-            unchecked {
-                ++i;
+        }
+        if (recipients[2] != address(0)) {
+            if (fees[2] != 0) {
+                _transferFungibleTokens(currency, sender, recipients[2], fees[2]);
             }
         }
     }


### PR DESCRIPTION
24698 -> 24674

```
testTakerBidMultipleOrdersSignedERC721() (gas: -251 (-0.000%))
testTakerAskMultipleOrdersSignedERC721() (gas: -251 (-0.000%))
testTakerAskCollectionOrderWithMerkleTreeERC721() (gas: -251 (-0.009%))
testCannotExecuteAnotherOrderAtNonceIfExecutionIsInProgress() (gas: -251 (-0.012%))
testTokenIdsRangeERC721() (gas: -251 (-0.012%))
testTakerAskForceAmountOneIfERC721() (gas: -251 (-0.012%))
testTokenIdsRangeERC1155() (gas: -251 (-0.012%))
testTakerAskCollectionOrderERC721(uint256) (gas: -251 (-0.012%))
testDutchAuction(uint256) (gas: -251 (-0.012%))
testTakerAskERC721BundleNoRoyalties() (gas: -251 (-0.017%))
testTakerBidERC721BundleNoRoyalties() (gas: -251 (-0.017%))
testCreatorRoyaltiesGetPaidForERC2981WithBundles() (gas: -327 (-0.019%))
testMultiFill() (gas: -502 (-0.020%))
testCreatorRoyaltiesGetPaidForRoyaltyFeeManagerWithBundles() (gas: -327 (-0.021%))
testTakerAskERC721BundleWithRoyaltiesFromRegistry() (gas: -327 (-0.021%))
testTakerBidERC721BundleWithRoyaltiesFromRegistry() (gas: -327 (-0.021%))
testTakerAskERC721WithAffiliateButWithoutRoyalty() (gas: -251 (-0.023%))
testTakerBidERC721WithAffiliateButWithoutRoyalty() (gas: -251 (-0.024%))
testFloorFromChainlinkPremiumFixedAmountDesiredSalePriceLessThanMinPrice() (gas: -251 (-0.029%))
testFloorFromChainlinkPremiumFixedAmountDesiredSalePriceGreaterThanMinPrice() (gas: -251 (-0.029%))
testFloorFromChainlinkPremiumFixedAmountDesiredSalePriceEqualToMinPrice() (gas: -251 (-0.029%))
testFloorFromChainlinkDiscountFixedAmountDesiredDiscountedPriceGreaterThanOrEqualToMaxPrice() (gas: -251 (-0.030%))
testFloorFromChainlinkDiscountFixedAmountDesiredDiscountedPriceLessThanMaxPrice() (gas: -251 (-0.030%))
testFloorFromChainlinkDiscountBasisPointsDesiredDiscountedPriceGreaterThanOrEqualToMaxPrice() (gas: -251 (-0.030%))
testFloorFromChainlinkDiscountBasisPointsDesiredDiscountedPriceLessThanMaxPrice() (gas: -251 (-0.030%))
testUSDDynamicAskUSDValueLessThanMinAcceptedEthValue() (gas: -251 (-0.031%))
testUSDDynamicAskUSDValueLessThanOneETH() (gas: -251 (-0.031%))
testUSDDynamicAskUSDValueGreaterThanOrEqualToMinAcceptedEthValue() (gas: -251 (-0.031%))
testCannotExecuteAnOrderTwice() (gas: -327 (-0.031%))
testCreatorRoyaltiesGetPaidForRoyaltyFeeManager() (gas: -327 (-0.031%))
testTakerAskERC721WithRoyaltiesFromRegistry() (gas: -327 (-0.031%))
testUSDDynamicAskBidderOverpaid() (gas: -251 (-0.031%))
testTakerBidERC721WithRoyaltiesFromRegistry() (gas: -327 (-0.032%))
testCreatorRoyaltiesGetPaidForERC2981() (gas: -327 (-0.032%))
testFloorFromChainlinkPremiumBasisPointsDesiredSalePriceLessThanMinPrice() (gas: -251 (-0.060%))
testFloorFromChainlinkPremiumBasisPointsDesiredSalePriceGreaterThanMinPrice() (gas: -251 (-0.060%))
testFloorFromChainlinkPremiumBasisPointsDesiredSalePriceEqualToMinPrice() (gas: -251 (-0.060%))
testThreeTakerBidsERC721() (gas: -753 (-0.092%))
testThreeTakerBidsERC721OneFails() (gas: -1004 (-0.093%))
testMultipleTakerBidsERC721WithAffiliateButWithoutRoyalty() (gas: -1757 (-0.116%))
Overall gas change: -13736 (-1.231%)
```