### PR TITLE
perf: Use XOR for length checks

### DIFF
--- a/contracts/LooksRareProtocol.sol
+++ b/contracts/LooksRareProtocol.sol
@@ -148,9 +148,7 @@ contract LooksRareProtocol is
             uint256 length = takerBids.length;
             if (
                 length == 0 ||
-                makerAsks.length != length ||
-                makerSignatures.length != length ||
-                merkleTrees.length != length
+                (makerAsks.length ^ length) | (makerSignatures.length ^ length) | (merkleTrees.length ^ length) != 0
             ) revert WrongLengths();
         }
 


### PR DESCRIPTION
```
testMultipleTakerBidsERC721WithAffiliateButWithoutRoyalty() (gas: -35 (-0.002%))
testThreeTakerBidsERC721() (gas: -35 (-0.004%))
testThreeTakerBidsERC721OneFails() (gas: -70 (-0.006%))
Overall gas change: -140 (-0.013%)
```