### PR TITLE
perf: Improve incrementBidAskNonces gas usage

### DIFF
--- a/contracts/NonceManager.sol
+++ b/contracts/NonceManager.sol
@@ -69,13 +69,17 @@ contract NonceManager is INonceManager {
      * @param ask Whether to increment the user ask nonce
      */
     function incrementBidAskNonces(bool bid, bool ask) external {
+        uint112 _bidNonce = userBidAskNonces[msg.sender].bidNonce;
+        uint112 _askNonce = userBidAskNonces[msg.sender].askNonce;
         if (bid) {
-            userBidAskNonces[msg.sender].bidNonce++;
+            _bidNonce++;
+            userBidAskNonces[msg.sender].bidNonce = _bidNonce;
         }
         if (ask) {
-            userBidAskNonces[msg.sender].askNonce++;
+            _askNonce++;
+            userBidAskNonces[msg.sender].askNonce = _askNonce;
         }
 
-        emit NewBidAskNonces(userBidAskNonces[msg.sender].bidNonce, userBidAskNonces[msg.sender].askNonce);
+        emit NewBidAskNonces(_bidNonce, _askNonce);
     }
 }


### PR DESCRIPTION
```
testCannotExecuteOrderIfWrongUserGlobalBidNonce() (gas: -152 (-0.116%))
testCannotExecuteOrderIfWrongUserGlobalAskNonce() (gas: -208 (-0.153%))
Overall gas change: -360 (-0.268%)
```