### PR TITLE
refactor: Make bid/ask nonces uint128

### DIFF
--- a/contracts/NonceManager.sol
+++ b/contracts/NonceManager.sol
@@ -69,8 +69,8 @@ contract NonceManager is INonceManager {
      * @param ask Whether to increment the user ask nonce
      */
     function incrementBidAskNonces(bool bid, bool ask) external {
-        uint112 _bidNonce = userBidAskNonces[msg.sender].bidNonce;
-        uint112 _askNonce = userBidAskNonces[msg.sender].askNonce;
+        uint128 _bidNonce = userBidAskNonces[msg.sender].bidNonce;
+        uint128 _askNonce = userBidAskNonces[msg.sender].askNonce;
         if (bid) {
             _bidNonce++;
             userBidAskNonces[msg.sender].bidNonce = _bidNonce;

--- a/contracts/helpers/OrderValidator.sol
+++ b/contracts/helpers/OrderValidator.sol
@@ -135,7 +135,7 @@ contract OrderValidator {
         OrderStructs.MakerAsk calldata makerAsk
     ) public view returns (uint256 validationCode) {
         // 1. Check global ask nonce
-        (, uint112 globalAskNonce) = looksRareProtocol.userBidAskNonces(makerAsk.signer);
+        (, uint128 globalAskNonce) = looksRareProtocol.userBidAskNonces(makerAsk.signer);
         if (makerAsk.askNonce < globalAskNonce) return USER_GLOBAL_ASK_NONCE_HIGHER;
         if (makerAsk.askNonce > globalAskNonce) return USER_GLOBAL_ASK_NONCE_LOWER;
 
@@ -156,7 +156,7 @@ contract OrderValidator {
         OrderStructs.MakerBid calldata makerBid
     ) public view returns (uint256 validationCode) {
         // 1. Check global ask nonce
-        (uint112 globalBidNonce, ) = looksRareProtocol.userBidAskNonces(makerBid.signer);
+        (uint128 globalBidNonce, ) = looksRareProtocol.userBidAskNonces(makerBid.signer);
         if (makerBid.bidNonce < globalBidNonce) return USER_GLOBAL_ASK_NONCE_HIGHER;
         if (makerBid.bidNonce > globalBidNonce) return USER_GLOBAL_ASK_NONCE_LOWER;
 

--- a/contracts/interfaces/INonceManager.sol
+++ b/contracts/interfaces/INonceManager.sol
@@ -7,13 +7,13 @@ pragma solidity ^0.8.17;
  */
 interface INonceManager {
     // Events
-    event NewBidAskNonces(uint112 bidNonce, uint112 askNonce);
+    event NewBidAskNonces(uint128 bidNonce, uint128 askNonce);
     event OrderNoncesCancelled(uint256[] orderNonces);
     event SubsetNoncesCancelled(uint256[] subsetNonces);
 
     // Custom structs
     struct UserBidAskNonces {
-        uint112 bidNonce;
-        uint112 askNonce;
+        uint128 bidNonce;
+        uint128 askNonce;
     }
 }

--- a/contracts/libraries/OrderStructs.sol
+++ b/contracts/libraries/OrderStructs.sol
@@ -8,12 +8,12 @@ pragma solidity ^0.8.17;
  */
 library OrderStructs {
     // Maker ask hash used to compute maker ask order hash
-    // keccak256("MakerAsk(uint112 askNonce,uint256 subsetNonce,uint256 strategyId,uint256 assetType,uint256 orderNonce,address collection,address currency,address signer,uint256 startTime,uint256 endTime,uint256 minPrice,uint256[] itemIds,uint256[] amounts,bytes additionalParameters)")
-    bytes32 internal constant _MAKER_ASK_HASH = 0x4d568682d7de9faaf25c7c39fe3f61abb6b26fdba5919d8faaa138520f33f199;
+    // keccak256("MakerAsk(uint128 askNonce,uint256 subsetNonce,uint256 strategyId,uint256 assetType,uint256 orderNonce,address collection,address currency,address signer,uint256 startTime,uint256 endTime,uint256 minPrice,uint256[] itemIds,uint256[] amounts,bytes additionalParameters)")
+    bytes32 internal constant _MAKER_ASK_HASH = 0xe456ddf325d41020a456c6df6c94e31d12bc3ae1ac78afc1e2069f85e5c86703;
 
     // Maker bid hash used to compute maker bid order hash
-    // keccak256("MakerBid(uint112 bidNonce,uint256 subsetNonce,uint256 strategyId,uint256 assetType,uint256 orderNonce,address collection,address currency,address signer,uint256 startTime,uint256 endTime,uint256 maxPrice,uint256[] itemIds,uint256[] amounts,bytes additionalParameters)")
-    bytes32 internal constant _MAKER_BID_HASH = 0xd63d06f35a2b56e3d4553a6a5dfcf486da7dcd5a93c2a10b9a78b47c61b485a1;
+    // keccak256("MakerBid(uint128 bidNonce,uint256 subsetNonce,uint256 strategyId,uint256 assetType,uint256 orderNonce,address collection,address currency,address signer,uint256 startTime,uint256 endTime,uint256 maxPrice,uint256[] itemIds,uint256[] amounts,bytes additionalParameters)")
+    bytes32 internal constant _MAKER_BID_HASH = 0xdd33dda38569330c45d869f164c11209f07a1d5b782adc09bfd2137a134ac090;
 
     // Merkle root hash used to compute merkle root order (proof is not included in the hash)
     // keccak256("MerkleTree(bytes32 root)")
@@ -40,7 +40,7 @@ library OrderStructs {
      * @param additionalParameters Extra data specific for the order (e.g., it can contain start price for Dutch Auction)
      */
     struct MakerAsk {
-        uint112 askNonce;
+        uint128 askNonce;
         uint256 subsetNonce;
         uint256 strategyId;
         uint256 assetType;
@@ -73,7 +73,7 @@ library OrderStructs {
      * @param additionalParameters Extra data specific for the order (e.g., it can contain a merkle root for specific strategies)
      */
     struct MakerBid {
-        uint112 bidNonce;
+        uint128 bidNonce;
         uint256 subsetNonce;
         uint256 strategyId;
         uint256 assetType;

--- a/test/foundry/NonceInvalidation.t.sol
+++ b/test/foundry/NonceInvalidation.t.sol
@@ -76,7 +76,7 @@ contract NonceInvalidationTest is INonceManager, ProtocolBase {
      * Cannot execute an order if maker is at a different global ask nonce than signed
      */
     function testCannotExecuteOrderIfWrongUserGlobalAskNonce() public {
-        uint112 userGlobalAskNonce = 1;
+        uint128 userGlobalAskNonce = 1;
         uint256 itemId = 420;
 
         // Mint asset
@@ -132,7 +132,7 @@ contract NonceInvalidationTest is INonceManager, ProtocolBase {
      * Cannot execute an order if maker is at a different global bid nonce than signed
      */
     function testCannotExecuteOrderIfWrongUserGlobalBidNonce() public {
-        uint112 userGlobalBidNonce = 1;
+        uint128 userGlobalBidNonce = 1;
         uint256 itemId = 420;
 
         // Prepare the order hash

--- a/test/foundry/utils/ProtocolHelpers.sol
+++ b/test/foundry/utils/ProtocolHelpers.sol
@@ -18,7 +18,7 @@ contract ProtocolHelpers is TestHelpers, TestParameters {
     bytes32 internal _domainSeparator;
 
     function _createSingleItemMakerAskOrder(
-        uint112 askNonce,
+        uint128 askNonce,
         uint256 subsetNonce,
         uint256 strategyId,
         uint256 assetType,
@@ -53,7 +53,7 @@ contract ProtocolHelpers is TestHelpers, TestParameters {
     }
 
     function _createMultiItemMakerAskOrder(
-        uint112 askNonce,
+        uint128 askNonce,
         uint256 subsetNonce,
         uint256 strategyId,
         uint256 assetType,
@@ -84,7 +84,7 @@ contract ProtocolHelpers is TestHelpers, TestParameters {
     }
 
     function _createSingleItemMakerBidOrder(
-        uint112 bidNonce,
+        uint128 bidNonce,
         uint256 subsetNonce,
         uint256 strategyId,
         uint256 assetType,
@@ -118,7 +118,7 @@ contract ProtocolHelpers is TestHelpers, TestParameters {
     }
 
     function _createMultiItemMakerBidOrder(
-        uint112 bidNonce,
+        uint128 bidNonce,
         uint256 subsetNonce,
         uint256 strategyId,
         uint256 assetType,


### PR DESCRIPTION
```
testFloorFromChainlinkPremiumBasisPointsDesiredSalePriceGreaterThanMinPrice() (gas: 1 (0.000%))
testTakerBidERC721WithRoyaltiesFromRegistry() (gas: 3 (0.000%))
testFloorFromChainlinkPremiumMakerAskItemIdsLengthNotOne() (gas: 1 (0.001%))
testUSDDynamicAskUSDValueGreaterThanOrEqualToMinAcceptedEthValue() (gas: 2 (0.001%))
testFloorFromChainlinkPremiumTakerBidAmountNotOne() (gas: 2 (0.001%))
testCreatorRoyaltiesRevertForEIP2981WithBundlesIfInfoDiffer() (gas: -9 (-0.001%))
testTakerBidTooLow() (gas: 2 (0.001%))
testCreatorRoyaltiesGetPaidForRoyaltyFeeManager() (gas: -7 (-0.001%))
testItemIdsMismatch() (gas: 2 (0.001%))
testOraclePriceNotRecentEnough() (gas: 2 (0.001%))
testCreatorRoyaltiesGetPaidForERC2981WithBundles() (gas: 13 (0.001%))
testCreatorRebatesArePaidForRoyaltyFeeManager() (gas: -9 (-0.001%))
testCreatorRoyaltiesGetPaidForERC2981() (gas: -9 (-0.001%))
testTakerAskERC721BundleNoRoyalties() (gas: 11 (0.002%))
testFloorFromChainlinkPremiumOraclePriceNotRecentEnough() (gas: 3 (0.002%))
testTakerBidERC721BundleNoRoyalties() (gas: -12 (-0.002%))
testMakerBidItemIdsLowerBandHigherThanOrEqualToUpperBand() (gas: 26 (0.002%))
testFloorFromChainlinkDiscountAskTooHigh() (gas: 4 (0.002%))
testFloorFromChainlinkDiscountMakerBidAmountNotOne() (gas: 4 (0.002%))
testCreatorRebatesArePaidForERC2981() (gas: 13 (0.002%))
testCannotExecuteOrderIfSubsetNonceIsUsed() (gas: 3 (0.002%))
testCreatorRoyaltiesRevertIfFeeHigherThanLimit() (gas: -15 (-0.002%))
testFloorFromChainlinkPremiumFixedAmountDesiredSalePriceEqualToMinPrice() (gas: -10 (-0.003%))
testCreatorRoyaltiesRevertForEIP2981WithBundlesIfInfoDiffer() (gas: -29 (-0.003%))
testTakerAskCollectionOrderERC721(uint256) (gas: -21 (-0.004%))
testTakerAskForceAmountOneIfERC721() (gas: 58 (0.004%))
testTokenIdsRangeERC721() (gas: 58 (0.004%))
testTakerAskPriceTooHigh() (gas: 58 (0.004%))
testTakerAskDuplicatedItemIds() (gas: 58 (0.004%))
testTakerAskOfferedAmountNotEqualToDesiredAmount() (gas: 58 (0.004%))
testTokenIdsRangeERC1155() (gas: 60 (0.004%))
testTakerAskERC721BundleWithRoyaltiesFromRegistry() (gas: 33 (0.004%))
testCreatorRoyaltiesGetPaidForRoyaltyFeeManagerWithBundles() (gas: -34 (-0.004%))
testTakerAskERC721WithRoyaltiesFromRegistry() (gas: -29 (-0.005%))
testFloorFromChainlinkPremiumFixedAmountDesiredSalePriceLessThanMinPrice() (gas: 15 (0.005%))
testCallerNotLooksRareProtocol() (gas: 67 (0.005%))
testThreeTakerBidsERC721WrongLengths() (gas: 22 (0.005%))
testNewStrategy() (gas: 44 (0.005%))
testCreatorRoyaltiesGetPaidForERC2981WithBundles() (gas: -53 (-0.005%))
testUSDDynamicAskInvalidChainlinkPrice() (gas: 15 (0.005%))
testTakerAskCollectionOrderWithMerkleTreeERC721() (gas: -66 (-0.005%))
testFloorFromChainlinkPremiumBasisPointsDesiredSalePriceLessThanMinPrice() (gas: -17 (-0.005%))
testInactiveStrategy() (gas: 79 (0.006%))
testTakerAskUnsortedItemIds() (gas: 80 (0.006%))
testFloorFromChainlinkDiscountCallerNotLooksRareProtocol() (gas: -9 (-0.006%))
testUSDDynamicAskUSDValueLessThanOneETH() (gas: -18 (-0.006%))
testTakerBidERC721BundleWithRoyaltiesFromRegistry() (gas: 54 (0.007%))
testCreatorRebatesArePaidForRoyaltyFeeManagerWithBundles() (gas: -55 (-0.007%))
testTakerBidGasGriefing() (gas: 23 (0.007%))
testUSDDynamicAskBidderOverpaid() (gas: -21 (-0.007%))
testFloorFromChainlinkDiscountFixedAmountDesiredDiscountedPriceGreaterThanOrEqualToMaxPrice() (gas: 24 (0.008%))
testUSDDynamicAskUSDValueLessThanMinAcceptedEthValue() (gas: 22 (0.008%))
testTakerBidERC721WithAffiliateButWithoutRoyalty() (gas: -51 (-0.008%))
testSetPriceFeedNotOwner() (gas: 1 (0.008%))
testSetPriceFeedNotOwner() (gas: 1 (0.008%))
testSetPriceFeedNotOwner() (gas: 1 (0.008%))
testCallerNotLooksRareProtocol() (gas: -10 (-0.008%))
testFloorFromChainlinkDiscountTakerAskAmountsLengthNotOne() (gas: -18 (-0.009%))
testFloorFromChainlinkDiscountTakerAskItemIdsLengthNotOne() (gas: -18 (-0.009%))
testSetMaximumLatencyLatencyToleranceTooHigh() (gas: -1 (-0.009%))
testFloorFromChainlinkDiscountOraclePriceNotRecentEnough() (gas: -18 (-0.010%))
testFloorFromChainlinkPremiumMakerAskAmountNotOne() (gas: -18 (-0.010%))
testFloorFromChainlinkPremiumFixedAmountDesiredSalePriceGreaterThanMinPrice() (gas: -31 (-0.010%))
testZeroAmount() (gas: -18 (-0.010%))
testCannotExecuteAnOrderTwice() (gas: -69 (-0.011%))
testTakerAskERC721WithAffiliateButWithoutRoyalty() (gas: -72 (-0.011%))
testFloorFromChainlinkPremiumWrongCurrency() (gas: 24 (0.012%))
testFloorFromChainlinkDiscountWrongCurrency() (gas: 26 (0.012%))
testFloorFromChainlinkPremiumMakerAskItemIdsLengthNotOne() (gas: 23 (0.013%))
testInactiveStrategy() (gas: 26 (0.013%))
testFloorFromChainlinkDiscountMakerBidAmountsLengthNotOne() (gas: 24 (0.013%))
testFloorFromChainlinkDiscountFixedAmountDesiredDiscountedPriceLessThanMaxPrice() (gas: -41 (-0.013%))
testCannotExecuteOrderIfWrongUserGlobalAskNonce() (gas: -18 (-0.013%))
testCannotExecuteAnOrderWhoseNonceIsCancelled() (gas: 75 (0.013%))
testFloorFromChainlinkPremiumOraclePriceNotRecentEnough() (gas: 25 (0.013%))
testInactiveStrategy() (gas: 28 (0.014%))
testThreeTakerBidsGasGriefing() (gas: -69 (-0.014%))
testFloorFromChainlinkDiscountChainlinkPriceLessThanOrEqualToZero() (gas: -48 (-0.014%))
testFloorFromChainlinkDiscountBasisPointsDesiredDiscountedPriceGreaterThanOrEqualToMaxPrice() (gas: -44 (-0.014%))
testThreeTakerBidsERC721OneFails() (gas: -175 (-0.017%))
testFloorFromChainlinkDiscountFixedAmountDesiredDiscountedAmountGreaterThanOrEqualToFloorPrice() (gas: -48 (-0.018%))
testThreeTakerBidsERC721() (gas: -155 (-0.020%))
testFloorFromChainlinkPremiumBidTooLow() (gas: -42 (-0.020%))
testCannotValidateOrderIfWrongFormat() (gas: -114 (-0.021%))
testFloorFromChainlinkDiscountBasisPointsDesiredDiscountedPriceLessThanMaxPrice() (gas: -64 (-0.021%))
testFloorFromChainlinkPremiumMakerAskAmountsLengthNotOne() (gas: -38 (-0.021%))
testZeroItemIdsLength() (gas: -21 (-0.021%))
testFloorFromChainlinkDiscountTakerAskAmountsLengthNotOne() (gas: -44 (-0.021%))
testFloorFromChainlinkDiscountTakerAskItemIdsLengthNotOne() (gas: -44 (-0.021%))
testFloorFromChainlinkDiscountBasisPointsDesiredDiscountBasisPointsGreaterThan10000() (gas: -44 (-0.021%))
testFloorFromChainlinkPremiumCallerNotLooksRareProtocol() (gas: -33 (-0.022%))
testInactiveStrategy() (gas: 45 (0.022%))
testFloorFromChainlinkPremiumBasisPointsDesiredSalePriceEqualToMinPrice() (gas: 68 (0.022%))
testFloorFromChainlinkPremiumBidTooLow() (gas: 46 (0.022%))
testFloorFromChainlinkPremiumTakerBidAmountNotOne() (gas: 46 (0.023%))
testFloorFromChainlinkPremiumMakerAskTakerBidItemIdsMismatch() (gas: 46 (0.023%))
testFloorFromChainlinkPremiumMakerAskAmountsLengthNotOne() (gas: -42 (-0.023%))
testFloorFromChainlinkDiscountOraclePriceNotRecentEnough() (gas: -44 (-0.023%))
testFloorFromChainlinkPremiumCallerNotLooksRareProtocol() (gas: 36 (0.024%))
testMultipleTakerBidsERC721WithAffiliateButWithoutRoyalty() (gas: -355 (-0.025%))
testFloorFromChainlinkDiscountPriceFeedNotAvailable() (gas: -42 (-0.025%))
testFloorFromChainlinkPremiumMakerAskAmountNotOne() (gas: 48 (0.026%))
testTakerAskMultipleOrdersSignedERC721() (gas: 161052 (0.027%))
testFloorFromChainlinkPremiumPriceFeedNotAvailable() (gas: 45 (0.028%))
testItemIdsAndAmountsLengthMismatch() (gas: 44 (0.029%))
testFloorFromChainlinkDiscountAskTooHigh() (gas: -62 (-0.029%))
testFloorFromChainlinkDiscountChainlinkPriceLessThanOrEqualToZero() (gas: -100 (-0.029%))
testFloorFromChainlinkDiscountTakerAskZeroAmount() (gas: -61 (-0.030%))
testFloorFromChainlinkDiscountWrongCurrency() (gas: -65 (-0.031%))
testInactiveStrategy() (gas: 67 (0.032%))
testFloorFromChainlinkPremiumWrongCurrency() (gas: 68 (0.033%))
testFloorFromChainlinkDiscountMakerBidAmountsLengthNotOne() (gas: -62 (-0.033%))
testFloorFromChainlinkPremiumMakerAskTakerBidItemIdsMismatch() (gas: 68 (0.034%))
testFloorFromChainlinkPremiumChainlinkPriceLessThanOrEqualToZero() (gas: 111 (0.034%))
testFloorFromChainlinkDiscountCallerNotLooksRareProtocol() (gas: -55 (-0.035%))
testCannotExecuteOrderIfWrongUserGlobalBidNonce() (gas: -53 (-0.040%))
testFloorFromChainlinkDiscountPriceFeedNotAvailable() (gas: -68 (-0.041%))
testFloorFromChainlinkPremiumPriceFeedNotAvailable() (gas: 67 (0.041%))
testFloorFromChainlinkDiscountTakerAskZeroAmount() (gas: -87 (-0.042%))
testMultiFill() (gas: 872 (0.044%))
testCannotValidateOrderIfWrongTimestamps() (gas: -67 (-0.048%))
testCannotExecuteAnotherOrderAtNonceIfExecutionIsInProgress() (gas: 809 (0.049%))
testInactiveStrategy() (gas: 89 (0.050%))
testAddTransferManagerForAssetType() (gas: 22 (0.054%))
testFloorFromChainlinkDiscountMakerBidAmountNotOne() (gas: -107 (-0.057%))
testInactiveStrategy() (gas: 879 (0.057%))
testStartPriceTooLow() (gas: 803 (0.057%))
testZeroAmount() (gas: -42 (-0.060%))
testDutchAuction(uint256) (gas: 910 (0.062%))
testZeroItemIdsLength() (gas: 844 (0.063%))
testItemIdsAndAmountsLengthMismatch() (gas: 892 (0.064%))
testCallerNotLooksRareProtocol() (gas: 878 (0.065%))
testTakerBidTooLow(uint256) (gas: 910 (0.065%))
testItemIdsMismatch() (gas: 910 (0.065%))
testZeroAmount() (gas: 910 (0.065%))
testCancelOrderNonces() (gas: 42 (0.066%))
testAmountsLengthNotOne() (gas: -87 (-0.066%))
testItemIdsLengthNotOne() (gas: -87 (-0.067%))
testTakerAskMultipleOrdersSignedERC721WrongMerkleProof() (gas: 11420 (0.068%))
testInactiveStrategy() (gas: 953 (0.068%))
testTakerBidMultipleOrdersSignedERC721WrongMerkleProof() (gas: -12737 (-0.077%))
testNewStrategy() (gas: 844 (0.078%))
testAmountsMismatch() (gas: -109 (-0.084%))
testOwnerCanDiscontinueStrategy() (gas: 22 (0.087%))
testBidAskAmountMismatch() (gas: -62 (-0.088%))
testPriceMismatch() (gas: -62 (-0.089%))
testNewStrategy() (gas: 844 (0.090%))
testUpdateDomainSeparator() (gas: -22 (-0.097%))
testTakerBidMultipleOrdersSignedERC721() (gas: -601951 (-0.098%))
testSetPriceFeed() (gas: 45 (0.112%))
testSetPriceFeed() (gas: 45 (0.112%))
testSetPriceFeed() (gas: 45 (0.112%))
testNewStrategies() (gas: 22 (0.138%))
testExecuteMultipleTakerBidsReentrancy() (gas: 1610 (0.144%))
testTakerAskReentrancy() (gas: 1595 (0.156%))
testTakerBidReentrancy() (gas: 1659 (0.158%))
testInitialStates() (gas: 22 (0.162%))
testNewStrategy() (gas: 22 (0.163%))
testAddTransferManagerForAssetTypeNotOwner() (gas: 22 (0.172%))
testOwnerCanChangeStrategyProtocolFeeAndDeactivateRoyalty() (gas: 44 (0.174%))
testInitialStates() (gas: -22 (-0.177%))
testSetPriceFeedNotOwner() (gas: 23 (0.181%))
testSetMaximumLatencyLatencyToleranceTooHigh() (gas: 22 (0.202%))
testSetProtocolFeeRecipientNotOwner() (gas: 22 (0.208%))
testUpdateDomainSeparatorSameDomainSeparator() (gas: -22 (-0.211%))
testSetMaximumLatencyLatencyToleranceTooHigh() (gas: -23 (-0.211%))
testSetMaximumLatencyLatencyToleranceTooHigh() (gas: -23 (-0.212%))
testSetMaximumLatencyNotOwner() (gas: -23 (-0.219%))
testSetCreatorFeeManager() (gas: -43 (-0.221%))
testSetProtocolFeeRecipient() (gas: -44 (-0.226%))
testAdjustETHGasLimitForTransfer() (gas: -44 (-0.233%))
testAddTransferManagerForAssetTypeAlreadySet() (gas: 44 (0.280%))
testOwnerRevertionsForWrongParametersAddStrategy() (gas: 66 (0.314%))
testSetMaximumCreatorFeeBp() (gas: 66 (0.339%))
testOwnerRevertionsForWrongParametersUpdateStrategy() (gas: 111 (0.364%))
testAddStrategyNoSelector() (gas: 44 (0.370%))
testSetMaximumLatencyLatencyToleranceTooHigh() (gas: -44 (-0.403%))
testSetMaximumCreatorFeeBpTooHigh() (gas: 66 (0.585%))
testSetMaximumCreatorFeeBpNotOwner() (gas: 88 (0.836%))
Overall gas change: -425939 (3.322%)
```

`uint128 gas report`

```
╭────────────────────────────────────────────────────────────┬─────────────────┬────────┬────────┬────────┬─────────╮
│ contracts/LooksRareProtocol.sol:LooksRareProtocol contract ┆                 ┆        ┆        ┆        ┆         │
╞════════════════════════════════════════════════════════════╪═════════════════╪════════╪════════╪════════╪═════════╡
│ Deployment Cost                                            ┆ Deployment Size ┆        ┆        ┆        ┆         │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ 4982520                                                    ┆ 24807           ┆        ┆        ┆        ┆         │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ Function Name                                              ┆ min             ┆ avg    ┆ median ┆ max    ┆ # calls │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ addStrategy                                                ┆ 3083            ┆ 26115  ┆ 25574  ┆ 32374  ┆ 148     │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ addTransferManagerForAssetType                             ┆ 2682            ┆ 11452  ┆ 4883   ┆ 26792  ┆ 3       │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ adjustETHGasLimitForTransfer                               ┆ 2467            ┆ 5494   ┆ 5494   ┆ 8521   ┆ 2       │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ cancelOrderNonces                                          ┆ 24739           ┆ 33949  ┆ 33949  ┆ 43159  ┆ 2       │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ cancelSubsetNonces                                         ┆ 24726           ┆ 24726  ┆ 24726  ┆ 24726  ┆ 1       │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ chainId                                                    ┆ 352             ┆ 352    ┆ 352    ┆ 352    ┆ 1       │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ countStrategies                                            ┆ 2396            ┆ 2396   ┆ 2396   ┆ 2396   ┆ 1       │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ creatorFeeManager                                          ┆ 404             ┆ 404    ┆ 404    ┆ 404    ┆ 1       │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ domainSeparator                                            ┆ 394             ┆ 404    ┆ 394    ┆ 2394   ┆ 198     │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ executeMultipleTakerBids                                   ┆ 1643            ┆ 174690 ┆ 125836 ┆ 621926 ┆ 10      │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ executeTakerAsk                                            ┆ 1182            ┆ 64808  ┆ 41336  ┆ 164140 ┆ 90      │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ executeTakerBid                                            ┆ 1159            ┆ 62427  ┆ 41562  ┆ 156601 ┆ 69      │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ incrementBidAskNonces                                      ┆ 24325           ┆ 24330  ┆ 24330  ┆ 24336  ┆ 2       │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ managerSelectorOfAssetType                                 ┆ 593             ┆ 1926   ┆ 2593   ┆ 2593   ┆ 3       │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ maximumCreatorFeeBp                                        ┆ 412             ┆ 1412   ┆ 1412   ┆ 2412   ┆ 2       │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ protocolFeeRecipient                                       ┆ 425             ┆ 425    ┆ 425    ┆ 425    ┆ 1       │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ restrictedExecuteTakerBid                                  ┆ 38731           ┆ 69852  ┆ 59183  ┆ 145692 ┆ 17      │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ setCreatorFeeManager                                       ┆ 1823            ┆ 22901  ┆ 23723  ┆ 23723  ┆ 204     │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ setMaximumCreatorFeeBp                                     ┆ 2584            ┆ 4641   ┆ 2625   ┆ 8714   ┆ 3       │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ setProtocolFeeRecipient                                    ┆ 1854            ┆ 1891   ┆ 1854   ┆ 8654   ┆ 198     │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ strategyInfo                                               ┆ 828             ┆ 2272   ┆ 2828   ┆ 2828   ┆ 18      │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ updateAffiliateController                                  ┆ 25755           ┆ 25755  ┆ 25755  ┆ 25755  ┆ 3       │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ updateAffiliateProgramStatus                               ┆ 6629            ┆ 6629   ┆ 6629   ┆ 6629   ┆ 3       │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ updateAffiliateRate                                        ┆ 24110           ┆ 24110  ┆ 24110  ┆ 24110  ┆ 3       │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ updateCurrencyWhitelistStatus                              ┆ 24180           ┆ 24200  ┆ 24180  ┆ 26180  ┆ 396     │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ updateDomainSeparator                                      ┆ 2370            ┆ 6843   ┆ 6843   ┆ 11317  ┆ 2       │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ updateStrategy                                             ┆ 2883            ┆ 6798   ┆ 3401   ┆ 12201  ┆ 19      │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ userOrderNonce                                             ┆ 675             ┆ 856    ┆ 675    ┆ 2675   ┆ 44      │
╰────────────────────────────────────────────────────────────┴─────────────────┴────────┴────────┴────────┴─────────╯
```