### PR TITLE
perf: ReentrancyGuard packing

### DIFF
--- a/contracts/LooksRareProtocol.sol
+++ b/contracts/LooksRareProtocol.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.17;
 
 // LooksRare unopinionated libraries
 import {SignatureChecker} from "@looksrare/contracts-libs/contracts/SignatureChecker.sol";
-import {ReentrancyGuard} from "@looksrare/contracts-libs/contracts/ReentrancyGuard.sol";
 import {LowLevelETHReturnETHIfAnyExceptOneWei} from "@looksrare/contracts-libs/contracts/lowLevelCallers/LowLevelETHReturnETHIfAnyExceptOneWei.sol";
 import {LowLevelWETH} from "@looksrare/contracts-libs/contracts/lowLevelCallers/LowLevelWETH.sol";
 import {LowLevelERC20Transfer} from "@looksrare/contracts-libs/contracts/lowLevelCallers/LowLevelERC20Transfer.sol";
@@ -66,7 +65,6 @@ LOOKSRARELOOKSRARELOOKSRLOOKSRARELOOKSRARELOOKSRARELOOKSRARELOOKSRLOOKSRARELOOKS
 contract LooksRareProtocol is
     ILooksRareProtocol,
     TransferSelectorNFT,
-    ReentrancyGuard,
     LowLevelETHReturnETHIfAnyExceptOneWei,
     LowLevelWETH,
     LowLevelERC20Transfer

--- a/contracts/TransferSelectorNFT.sol
+++ b/contracts/TransferSelectorNFT.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.17;
 
 // Direct dependencies
 import {ExecutionManager} from "./ExecutionManager.sol";
+import {PackableReentrancyGuard} from "@looksrare/contracts-libs/contracts/PackableReentrancyGuard.sol";
 
 // Interfaces
 import {ITransferSelectorNFT} from "./interfaces/ITransferSelectorNFT.sol";
@@ -12,7 +13,7 @@ import {ITransferSelectorNFT} from "./interfaces/ITransferSelectorNFT.sol";
  * @notice This contract handles the logic for transferring non-fungible items.
  * @author LooksRare protocol team (👀,💎)
  */
-contract TransferSelectorNFT is ITransferSelectorNFT, ExecutionManager {
+contract TransferSelectorNFT is ITransferSelectorNFT, ExecutionManager, PackableReentrancyGuard {
     /**
      * @notice It returns the transfer manager address and the associated bytes4
      * selector used to transfer assets for this asset type.

--- a/package.json
+++ b/package.json
@@ -78,6 +78,6 @@
   },
   "dependencies": {
     "@chainlink/contracts": "^0.5.1",
-    "@looksrare/contracts-libs": "2.5.0"
+    "@looksrare/contracts-libs": "2.5.1"
   }
 }

--- a/test/foundry/LooksRareProtocol.t.sol
+++ b/test/foundry/LooksRareProtocol.t.sol
@@ -223,7 +223,7 @@ contract LooksRareProtocolTest is ProtocolBase {
         vm.expectEmit(true, false, false, true);
         emit NewGasLimitETHTransfer(10_000);
         looksRareProtocol.updateETHGasLimitForTransfer(10_000);
-        assertEq(uint256(vm.load(address(looksRareProtocol), bytes32(uint256(16)))), 10_000);
+        assertEq(uint256(vm.load(address(looksRareProtocol), bytes32(uint256(15)))), 10_000);
     }
 
     function testUpdateETHGasLimitForTransferRevertsIfTooLow() public asPrankedUser(_owner) {
@@ -232,7 +232,7 @@ contract LooksRareProtocolTest is ProtocolBase {
         looksRareProtocol.updateETHGasLimitForTransfer(newGasLimitETHTransfer - 1);
 
         looksRareProtocol.updateETHGasLimitForTransfer(newGasLimitETHTransfer);
-        assertEq(uint256(vm.load(address(looksRareProtocol), bytes32(uint256(16)))), newGasLimitETHTransfer);
+        assertEq(uint256(vm.load(address(looksRareProtocol), bytes32(uint256(15)))), newGasLimitETHTransfer);
     }
 
     function testUpdateETHGasLimitForTransferNotOwner() public {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1034,10 +1034,10 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@looksrare/contracts-libs@2.5.0":
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/@looksrare/contracts-libs/-/contracts-libs-2.5.0.tgz#88719ba4a84fd8c5a2474ece7471bc30f5b3e8cd"
-  integrity sha512-RGErb/NZoCf5fDZzaOpOMP8MnTmwwZ9x3URNu0tDp5BHBRo4MCPb///dKNYFqPsy1PjBmYPRLRvkYn0JYUHhTw==
+"@looksrare/contracts-libs@2.5.1":
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/@looksrare/contracts-libs/-/contracts-libs-2.5.1.tgz#cc6c049e31bd16db7a309c02213eb6b18d717e52"
+  integrity sha512-Mddt94e25GzMFik9hkC77Wkwma4AjVLNCFXsKB0lMRMKf0wDq8/ko8CZEVfh+rqccBlhGwzGitPaCU1YJTIPeg==
 
 "@metamask/eth-sig-util@^4.0.0":
   version "4.0.1"
@@ -7604,8 +7604,6 @@ level-post@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/level-post/-/level-post-1.0.7.tgz#19ccca9441a7cc527879a0635000f06d5e8f27d0"
   integrity sha512-PWYqG4Q00asOrLhX7BejSajByB4EmG2GaKHfj3h5UmmZ2duciXLPGYWIjBzLECFWUGOZWlm5B20h/n3Gs3HKew==
-  dependencies:
-    ltgt "^2.1.2"
 
 level-sublevel@6.6.4:
   version "6.6.4"


### PR DESCRIPTION
@0xJurassicPunk I have tested this change also in `contracts-aggregator` and I am not convinced it will bring the same magnitude of gas savings to the aggregator (in fact it is probably worse), so that means the `uint8` version of `ReentrancyGuard` can only be used here. We can either make the `ReentrancyGuard` in `contracts-libs` `uint8` or we can implement it locally in `contracts-exchange-v2`. For now the file is copied into `/libraries`, let me know if you want it to become the official `contracts-libs` version instead.