### PR TITLE
perf: Cache in _transferToAskRecipientAndCreatorIfAny

### DIFF
--- a/contracts/LooksRareProtocol.sol
+++ b/contracts/LooksRareProtocol.sol
@@ -523,16 +523,18 @@ contract LooksRareProtocol is
         address bidUser
     ) private {
         // @dev There is no check for address(0), if the creator recipient is address(0), the fee is set to 0
-        if (feeAmounts[0] != 0) {
-            _transferFungibleTokens(currency, bidUser, recipients[0], feeAmounts[0]);
+        uint256 sellerProceed = feeAmounts[0];
+        if (sellerProceed != 0) {
+            _transferFungibleTokens(currency, bidUser, recipients[0], sellerProceed);
         }
 
         // @dev There is no check for address(0) since the ask recipient can never be address(0)
         // If ask recipient is the maker --> the signer cannot be the null address
         // If ask is the taker --> either it is the sender address or
         // if the recipient (in TakerAsk) is set to address(0), it is adjusted to the original taker address
-        if (feeAmounts[1] != 0) {
-            _transferFungibleTokens(currency, bidUser, recipients[1], feeAmounts[1]);
+        uint256 creatorFee = feeAmounts[1];
+        if (creatorFee != 0) {
+            _transferFungibleTokens(currency, bidUser, recipients[1], creatorFee);
         }
     }
 


### PR DESCRIPTION
```
testTakerBidMultipleOrdersSignedERC721() (gas: -2 (-0.000%))
testTakerAskMultipleOrdersSignedERC721() (gas: -2 (-0.000%))
testTakerAskCollectionOrderWithMerkleTreeERC721() (gas: -2 (-0.000%))
testCannotExecuteAnotherOrderAtNonceIfExecutionIsInProgress(uint256) (gas: -2 (-0.000%))
testDutchAuction(uint256,uint256,uint256,uint256) (gas: -2 (-0.000%))
testTokenIdsRangeERC721(uint256,uint256) (gas: -2 (-0.000%))
testMultiFill() (gas: -4 (-0.000%))
testTakerBidERC721BundleNoRoyalties() (gas: -2 (-0.000%))
testTakerAskERC721BundleNoRoyalties() (gas: -2 (-0.000%))
testTakerBidERC1155BundleNoRoyalties() (gas: -2 (-0.000%))
testTakerBidERC721WithAffiliateButWithoutRoyalty() (gas: -2 (-0.000%))
testTakerAskERC721WithAffiliateButWithoutRoyalty() (gas: -2 (-0.000%))
testTakerAskERC1155BundleNoRoyalties() (gas: -2 (-0.000%))
testCannotExecuteMultipleTakerBidsIfDifferentCurrencies() (gas: -2 (-0.000%))
testTakerBidERC721WithAddressZeroSpecifiedAsRecipient(uint256) (gas: -2 (-0.000%))
testTakerAskCollectionOrderERC721(uint256) (gas: -2 (-0.000%))
testTakerAskERC721WithAddressZeroSpecifiedAsRecipient(uint256) (gas: -2 (-0.000%))
testCannotTransferIfNoManagerSelectorForAssetType() (gas: -2 (-0.000%))
testTakerAskCannotTransferSandboxWithERC721AssetTypeButERC1155AssetTypeWorks() (gas: -2 (-0.001%))
testFloorFromChainlinkPremiumBasisPointsDesiredSalePriceLessThanMinPrice() (gas: -2 (-0.001%))
testFloorFromChainlinkPremiumFixedAmountDesiredSalePriceEqualToMinPrice() (gas: -2 (-0.001%))
testFloorFromChainlinkPremiumFixedAmountDesiredSalePriceGreaterThanMinPrice() (gas: -2 (-0.001%))
testFloorFromChainlinkPremiumFixedAmountDesiredSalePriceLessThanMinPrice() (gas: -2 (-0.001%))
testFloorFromChainlinkPremiumBasisPointsDesiredSalePriceGreaterThanMinPrice() (gas: -2 (-0.001%))
testFloorFromChainlinkPremiumBasisPointsDesiredSalePriceEqualToMinPrice() (gas: -2 (-0.001%))
testFloorFromChainlinkDiscountBasisPointsDesiredDiscountedPriceGreaterThanOrEqualToMaxPrice() (gas: -2 (-0.001%))
testFloorFromChainlinkDiscountBasisPointsDesiredDiscountedPriceLessThanMaxPrice() (gas: -2 (-0.001%))
testFloorFromChainlinkDiscountFixedAmountDesiredDiscountedPriceGreaterThanOrEqualToMaxPrice() (gas: -2 (-0.001%))
testFloorFromChainlinkDiscountFixedAmountDesiredDiscountedPriceLessThanMaxPrice() (gas: -2 (-0.001%))
testUSDDynamicAskBidderOverpaid() (gas: -2 (-0.001%))
testThreeTakerBidsERC721() (gas: -6 (-0.001%))
testUSDDynamicAskUSDValueLessThanMinAcceptedEthValue() (gas: -2 (-0.001%))
testUSDDynamicAskUSDValueLessThanOneETH() (gas: -2 (-0.001%))
testUSDDynamicAskUSDValueGreaterThanOrEqualToMinAcceptedEthValue() (gas: -2 (-0.001%))
testMultipleTakerBidsERC721WithAffiliateButWithoutRoyalty() (gas: -16 (-0.001%))
testTakerBidCannotTransferSandboxWithERC721AssetTypeButERC1155AssetTypeWorks() (gas: -4 (-0.001%))
testThreeTakerBidsERC721OneFails() (gas: -12 (-0.001%))
testBatchTakerAsk() (gas: -15 (-0.001%))
testThreeTakerBidsGasGriefing() (gas: -6 (-0.001%))
testCreatorRoyaltiesGetPaidForERC2981WithBundles() (gas: -19 (-0.002%))
testTakerBid() (gas: -19 (-0.002%))
testCreatorRoyaltiesGetPaidForERC2981WithBundles() (gas: -19 (-0.002%))
testTakerAsk() (gas: -19 (-0.002%))
testTakerBid() (gas: -19 (-0.002%))
testTakerAsk() (gas: -19 (-0.002%))
testTakerBidERC721BundleWithRoyaltiesFromRegistry() (gas: -19 (-0.002%))
testCreatorRebatesArePaidForRoyaltyFeeManagerWithBundles() (gas: -19 (-0.002%))
testTakerAskERC721BundleWithRoyaltiesFromRegistry() (gas: -19 (-0.002%))
testCreatorRoyaltiesGetPaidForRoyaltyFeeManagerWithBundles() (gas: -19 (-0.002%))
testTokenIdsRangeERC1155(uint256,uint256) (gas: 29 (0.003%))
testTakerAskERC721WithRoyaltiesFromRegistryWithDelegation() (gas: -19 (-0.003%))
testTakerBidERC721WithRoyaltiesFromRegistry(uint256) (gas: -19 (-0.003%))
testTakerBidERC721WithRoyaltiesFromRegistryWithDelegation() (gas: -19 (-0.003%))
testCannotExecuteAnOrderTwice() (gas: -19 (-0.003%))
testCreatorRebatesArePaidForRoyaltyFeeManager() (gas: -19 (-0.003%))
testCreatorRoyaltiesGetPaidForRoyaltyFeeManager() (gas: -19 (-0.003%))
testCreatorRebatesArePaidForERC2981() (gas: -19 (-0.003%))
testCreatorRoyaltiesGetPaidForERC2981() (gas: -19 (-0.003%))
testStartPriceTooLow(uint256,uint256,uint256,uint256) (gas: 40 (0.003%))
testExecuteMultipleTakerBidsOnERC1155ReceivedReentrancyOnlyInTheLastCall() (gas: -57 (-0.004%))
testExecuteMultipleTakerBids() (gas: -57 (-0.005%))
testExecuteMultipleTakerBids() (gas: -57 (-0.005%))
testTakerBidGasGriefing() (gas: -19 (-0.006%))
testTakerAskERC721WithRoyaltiesFromRegistry(uint256) (gas: -59 (-0.009%))
testCannotValidateOrderIfTooEarlyToExecute(uint256) (gas: 40 (0.032%))
testCannotValidateOrderIfTooLateToExecute(uint256) (gas: -40 (-0.032%))
testCannotValidateOrderIfMakerAskItemIdsLengthMismatch(uint256) (gas: 16931 (0.410%))
testCannotValidateOrderIfMakerBidItemIdsLengthMismatch(uint256) (gas: 16931 (0.411%))
Overall gas change: 33213 (0.734%)
```

On the surface it looks like gas increased, but it is coming from a length mismatch test with fuzzing turned on. Length mismatch isn't really a real scenario and if we take out the fuzzing then the gas change will be negative.