### PR TITLE
refactor: Put assetType and quoteType together

### DIFF
--- a/contracts/libraries/OrderStructs.sol
+++ b/contracts/libraries/OrderStructs.sol
@@ -17,12 +17,12 @@ library OrderStructs {
 
     /**
      * @notice Maker is the struct for a maker order.
+     * @param assetType Asset type (i.e. 0 = ERC721, 1 = ERC1155)
      * @param quoteType Quote type (i.e. 0 = BID, 1 = ASK)
      * @param globalNonce Global user order nonce for maker orders
      * @param subsetNonce Subset nonce (shared across bid/ask maker orders)
      * @param orderNonce Order nonce (it can be shared across bid/ask maker orders)
      * @param strategyId Strategy id
-     * @param assetType Asset type (i.e. 0 = ERC721, 1 = ERC1155)
      * @param collection Collection address
      * @param currency Currency address (@dev address(0) = ETH)
      * @param signer Signer address
@@ -34,12 +34,12 @@ library OrderStructs {
      * @param additionalParameters Extra data specific for the order
      */
     struct Maker {
+        AssetType assetType;
         QuoteType quoteType;
         uint256 globalNonce;
         uint256 subsetNonce;
         uint256 orderNonce;
         uint256 strategyId;
-        AssetType assetType;
         address collection;
         address currency;
         address signer;
@@ -92,12 +92,12 @@ library OrderStructs {
     bytes32 internal constant _MAKER_TYPEHASH =
         keccak256(
             "Maker("
+            "uint8 assetType,"
             "uint8 quoteType"
             "uint256 globalNonce,"
             "uint256 orderNonce,"
             "uint256 subsetNonce,"
             "uint256 strategyId,"
-            "uint8 assetType,"
             "address collection,"
             "address currency,"
             "address signer,"
@@ -137,12 +137,12 @@ library OrderStructs {
                 bytes.concat(
                     abi.encode(
                         _MAKER_TYPEHASH,
+                        maker.assetType,
                         maker.quoteType,
                         maker.globalNonce,
                         maker.subsetNonce,
                         maker.orderNonce,
                         maker.strategyId,
-                        maker.assetType,
                         maker.collection,
                         maker.currency
                     ),


### PR DESCRIPTION
```
testUSDDynamicAskUSDValueLessThanMinAcceptedEthValue() (gas: 3 (0.001%))
testUSDDynamicAskUSDValueGreaterThanOrEqualToMinAcceptedEthValue() (gas: 3 (0.001%))
testTakerAskCannotTransferSandboxWithERC721AssetTypeButERC1155AssetTypeWorks() (gas: 5 (0.001%))
testNewStrategy() (gas: 10 (0.002%))
testCannotExecuteIfNotWETHOrETH() (gas: -31 (-0.003%))
testCollectionOrderWithMerkleTreeRevertsIfItemIsFlagged() (gas: -2115 (-0.004%))
testInvalidSelector() (gas: -24 (-0.005%))
testTakerBidCannotTransferSandboxWithERC721AssetTypeButERC1155AssetTypeWorks() (gas: 17 (0.005%))
testInvalidSelector() (gas: -24 (-0.005%))
testUSDDynamicAskBidderOverpaid() (gas: -15 (-0.006%))
testMakerBidWrongAssetTypeERC1155() (gas: -91 (-0.006%))
testBatchTakerAsk() (gas: -88 (-0.007%))
testMakerBidInsufficientERC20Allowance() (gas: -141 (-0.007%))
testNewStrategy() (gas: 1 (0.007%))
testMakerBidERC721AmountNotEqualToOne() (gas: -91 (-0.008%))
testMakerBidZeroAmount() (gas: -91 (-0.008%))
testMakerBidMissingIsValidSignature() (gas: -91 (-0.008%))
testInactiveStrategy() (gas: -80 (-0.008%))
testMakerBidWrongAssetTypeERC721() (gas: -91 (-0.008%))
testMakerAskERC1155IsApprovedForAllDoesNotExist() (gas: -142 (-0.009%))
testCannotUpdateAffiliateRateIfNotAffiliateController() (gas: -1 (-0.009%))
testTokenIdsRangeERC1155(uint256,uint256) (gas: -105 (-0.009%))
testMakerAskERC1155BalanceInferiorToAmountThroughBalanceOf() (gas: -142 (-0.009%))
testUpdateAffiliateProgramStatusNotOwner() (gas: 1 (0.009%))
testMakerAskWrongAssetTypeERC1155() (gas: -139 (-0.010%))
testCannotExecuteMultipleTakerBidsIfDifferentCurrenciesIsAtomic() (gas: -60 (-0.010%))
testMakerAskERC1155BalanceOfDoesNotExist() (gas: -142 (-0.010%))
testMakerAskERC1155BalanceInferiorToAmountThroughBalanceOfBatch() (gas: -142 (-0.010%))
testCollectionOrderWithMerkleTreeRevertsIfLastTransferTimeIs0() (gas: -2031 (-0.010%))
testCollectionOrderWithMerkleTreeWorksIfItemIsNotFlaggedAndLastTransferIsRecentEnough() (gas: -2059 (-0.010%))
testUSDDynamicAskUSDValueLessThanOneETH() (gas: 25 (0.010%))
testCollectionOrderWithMerkleTreeRevertsIfItemIdDiffers(uint16) (gas: -2053 (-0.010%))
testCollectionOrderWithMerkleTreeRevertsIfSignatureExpires() (gas: -2093 (-0.010%))
testInactiveStrategy() (gas: -116 (-0.011%))
testInvalidMakerBidAdditionalParameters() (gas: -113 (-0.011%))
testCollectionOrderRevertsIfSignatureExpires() (gas: -1984 (-0.011%))
testNewStrategies() (gas: -1944 (-0.011%))
testCollectionOrderWithMerkleTreeRevertsIfTransferWithinCooldownPeriodOrTransferCooldownPeriodTooHigh() (gas: -2222 (-0.011%))
testCollectionOrderWorksIfItemIsNotFlaggedAndLastTransferIsRecentEnough() (gas: -2012 (-0.011%))
testCollectionOrderRevertsIfLastTransferTimeIs0() (gas: -2005 (-0.011%))
testCollectionOrderRevertsIfItemIdDiffers(uint16) (gas: -2006 (-0.011%))
testCollectionOrderRevertsIfItemIsFlagged() (gas: -2010 (-0.011%))
testMakerAskERC721NotAllTokensAreApproved() (gas: -144 (-0.011%))
testCollectionOrderRevertsIfTransferWithinCooldownPeriodOrTransferCooldownPeriodTooHigh() (gas: -2194 (-0.012%))
testMakerAskWrongAssetTypeERC721() (gas: -139 (-0.012%))
testMakerAskDoesNotOwnERC721() (gas: -151 (-0.012%))
testCannotTradeIfChainIdHasChanged(uint64) (gas: -55 (-0.012%))
testTakerAskItemIdsAmountsLengthMismatch() (gas: -137 (-0.012%))
testMakerAskLooksRareProtocolIsNotAWhitelistedOperator() (gas: -161 (-0.013%))
testCannotExecuteMultipleTakerBidsIfDifferentCurrenciesIsNonAtomic() (gas: -81 (-0.013%))
testTakerAskRevertsIfProofTooLarge() (gas: -84340 (-0.013%))
testTakerAskMultipleOrdersSignedERC721() (gas: -84296 (-0.014%))
testZeroAmount() (gas: -30 (-0.014%))
testTakerAskDuplicatedItemIds() (gas: -159 (-0.014%))
testTakerAskOfferedItemIdTooLow() (gas: -159 (-0.014%))
testZeroItemIdsLength() (gas: 11 (0.014%))
testNewStrategy() (gas: -77 (-0.016%))
testTakerAskUnsortedItemIds() (gas: -181 (-0.016%))
testTakerAskOfferedAmountNotEqualToDesiredAmount() (gas: -181 (-0.016%))
testTakerAskOfferedItemIdTooHigh() (gas: -181 (-0.016%))
testTakerAskRevertIfAmountIsZeroOrGreaterThanOneERC721() (gas: -188 (-0.016%))
testExecuteMultipleTakerBids() (gas: -206 (-0.017%))
testExecuteMultipleTakerBidsInvalidSignatures() (gas: -157 (-0.017%))
testTokenIdsRangeERC721(uint256,uint256) (gas: -205 (-0.017%))
testTakerAskCollectionOrderWithMerkleTreeERC721() (gas: -220 (-0.017%))
testCannotCallRestrictedExecuteTakerBid() (gas: -75 (-0.018%))
testThreeTakerBidsERC721LengthsInvalid() (gas: -77 (-0.018%))
testTakerBidTooLow(uint256,uint256,uint256,uint256) (gas: -208 (-0.018%))
testItemIdsAndAmountsLengthMismatch() (gas: -190 (-0.018%))
testZeroItemIdsLength() (gas: -186 (-0.019%))
testCannotExecuteAnOrderWhoseNonceIsCancelled(uint256) (gas: -117 (-0.019%))
testExecuteMultipleTakerBidsInvalidSignatures() (gas: -177 (-0.019%))
testTakerAsk() (gas: -201 (-0.020%))
testTakerAskCannotExecuteWithInvalidProof(uint256) (gas: -236 (-0.020%))
testStartPriceTooLow(uint256,uint256,uint256,uint256) (gas: -226 (-0.020%))
testDutchAuction(uint256,uint256,uint256,uint256) (gas: -236 (-0.020%))
testCannotTradeIfDomainSeparatorHasBeenUpdated(uint64) (gas: -99 (-0.021%))
testThreeTakerBidsERC721OneFails() (gas: -219 (-0.021%))
testZeroDesiredAmount() (gas: -239 (-0.022%))
testTakerAskCollectionOrderERC721(uint256) (gas: -132 (-0.022%))
testTakerBidRevertsIfProofTooLarge() (gas: -145967 (-0.022%))
testTakerAsk() (gas: -228 (-0.023%))
testTakerBidMultipleOrdersSignedERC721() (gas: -145949 (-0.023%))
testMakerBidItemIdsLowerBandHigherThanOrEqualToUpperBand() (gas: -264 (-0.023%))
testTakerAskInvalidSignature() (gas: -230 (-0.023%))
testExecuteMultipleTakerBids() (gas: -294 (-0.023%))
testTakerAskInvalidSignature() (gas: -230 (-0.024%))
testTakerBid() (gas: -253 (-0.024%))
testUSDDynamicAskChainlinkPriceInvalid() (gas: 76 (0.024%))
testTakerBid() (gas: -253 (-0.024%))
testTakerBidGasGriefing() (gas: -82 (-0.026%))
testTakerBidERC721WithAffiliateButWithoutRoyalty() (gas: -193 (-0.027%))
testCannotExecuteTransactionIfMakerAskWithStrategyForMakerBid() (gas: 573 (0.027%))
testTakerBidInvalidSignature() (gas: -259 (-0.028%))
testInvalidAmounts() (gas: -337 (-0.028%))
testCannotExecuteTransactionIfMakerBidWithStrategyForMakerAsk() (gas: 594 (0.028%))
testMakerBidAmountsLengthNotOne() (gas: -167 (-0.029%))
testCreatorRoyaltiesRevertForEIP2981WithBundlesIfAtLeastOneCallReverts(uint256) (gas: -256 (-0.029%))
testInvalidAmounts() (gas: -476 (-0.030%))
testTakerBidERC721BundleWithRoyaltiesFromRegistry() (gas: -251 (-0.030%))
testCreatorRoyaltiesGetPaidForERC2981WithBundles() (gas: -328 (-0.031%))
testTakerAskERC1155BundleNoRoyalties() (gas: -226 (-0.032%))
testTakerAskERC721WithAffiliateButWithoutRoyalty() (gas: -226 (-0.032%))
testCannotUpdateAffiliateRateIfRateHigherthan10000() (gas: 20 (0.033%))
testTakerAskERC721WithAddressZeroSpecifiedAsRecipient(uint256) (gas: -198 (-0.033%))
testTakerBidInvalidSignature() (gas: -299 (-0.033%))
testCreatorRoyaltiesGetPaidForERC2981WithBundles() (gas: -328 (-0.033%))
testCannotExecuteAnOrderTwice() (gas: -230 (-0.034%))
testCreatorRebatesArePaidForRoyaltyFeeManagerWithBundles() (gas: -284 (-0.034%))
testInactiveStrategy() (gas: -95 (-0.035%))
testInactiveStrategy() (gas: -95 (-0.035%))
testCannotTradeIfCurrencyInvalid() (gas: -193 (-0.035%))
testTakerAskERC721WithRoyaltiesFromRegistry(uint256) (gas: -242 (-0.035%))
testTakerBidERC721WithRoyaltiesFromRegistry(uint256) (gas: -249 (-0.036%))
testFloorFromChainlinkPremiumOraclePriceNotRecentEnough() (gas: -102 (-0.037%))
testFloorFromChainlinkPremiumChainlinkPriceLessThanOrEqualToZero() (gas: -164 (-0.038%))
testTakerAskERC721BundleNoRoyalties() (gas: -284 (-0.038%))
testTakerBidERC721WithRoyaltiesFromRegistryWithDelegation() (gas: -271 (-0.039%))
testFloorFromChainlinkPremiumMakerAskAmountNotOne() (gas: -123 (-0.039%))
testCreatorRebatesArePaidForRoyaltyFeeManager() (gas: -263 (-0.039%))
testFloorFromChainlinkPremiumChainlinkPriceLessThanOrEqualToZero() (gas: -172 (-0.040%))
testTakerBidERC1155BundleNoRoyalties() (gas: -295 (-0.040%))
testTakerAskERC721BundleWithRoyaltiesFromRegistry() (gas: -328 (-0.040%))
testTakerAskERC721WithRoyaltiesFromRegistryWithDelegation() (gas: -282 (-0.040%))
testTakerBidERC721WithAddressZeroSpecifiedAsRecipient(uint256) (gas: -249 (-0.040%))
testZeroAmount() (gas: -214 (-0.041%))
testItemIdsAndAmountsLengthMismatch() (gas: -53 (-0.041%))
testThreeTakerBidsERC721() (gas: -316 (-0.041%))
testTakerBidERC721BundleNoRoyalties() (gas: -317 (-0.042%))
testCanSignValidMakerAskEIP2098(uint256,uint256) (gas: -242 (-0.042%))
testCreatorRoyaltiesGetPaidForRoyaltyFeeManagerWithBundles() (gas: -351 (-0.043%))
testCreatorRoyaltiesGetPaidForERC2981() (gas: -292 (-0.045%))
testSetPriceFeed() (gas: 22 (0.045%))
testSetPriceFeed() (gas: 22 (0.045%))
testSetPriceFeed() (gas: 22 (0.045%))
testMultiFill() (gas: -724 (-0.045%))
testCanSignValidMakerBidEIP2098(uint256,uint256) (gas: -259 (-0.045%))
testFloorFromChainlinkDiscountFixedAmountDesiredDiscountedPriceLessThanMaxPrice() (gas: -157 (-0.045%))
testFloorFromChainlinkDiscountFixedAmountDesiredDiscountedAmountGreaterThanFloorPrice() (gas: -144 (-0.046%))
testFloorFromChainlinkPremiumBasisPointsDesiredSalePriceGreaterThanMinPrice() (gas: -165 (-0.046%))
testFloorFromChainlinkPremiumBasisPointsDesiredSalePriceEqualToMinPrice() (gas: -165 (-0.046%))
testPriceFeedCannotBeSetTwice() (gas: -22 (-0.046%))
testPriceFeedCannotBeSetTwice() (gas: -22 (-0.046%))
testCreatorRoyaltiesGetPaidForRoyaltyFeeManager() (gas: -315 (-0.047%))
testFloorFromChainlinkPremiumMakerAskItemIdsLengthNotOne() (gas: -117 (-0.047%))
testSetPriceFeed() (gas: -23 (-0.047%))
testCreatorRebatesArePaidForERC2981() (gas: -312 (-0.048%))
testTakerBidTooLow() (gas: -116 (-0.048%))
testCreatorRoyaltiesRevertForEIP2981WithBundlesIfInfoDiffer() (gas: -478 (-0.049%))
testPriceFeedCannotBeSetTwice() (gas: 23 (0.049%))
testPriceFeedCannotBeSetTwice() (gas: 23 (0.049%))
testCreatorRoyaltiesRevertForEIP2981WithBundlesIfInfoDiffer() (gas: -453 (-0.049%))
testOraclePriceNotRecentEnough() (gas: -116 (-0.049%))
testInactiveStrategy() (gas: -117 (-0.049%))
testFloorFromChainlinkPremiumOraclePriceNotRecentEnough() (gas: -138 (-0.050%))
testFloorFromChainlinkPremiumMakerAskAmountNotOne() (gas: -167 (-0.053%))
testDeriveProtocolParameters() (gas: -22 (-0.054%))
testInvalidSelector() (gas: 7 (0.054%))
testCreatorRoyaltiesRevertForEIP2981WithBundlesIfAtLeastOneCallReverts(uint256) (gas: -498 (-0.054%))
testAddStrategyNotV2Strategy() (gas: -43 (-0.054%))
testCannotTradeIfInvalidAmounts() (gas: -356 (-0.055%))
testFloorFromChainlinkPremiumMakerAskAmountsLengthNotOne() (gas: -139 (-0.055%))
testFloorFromChainlinkPremiumCurrencyInvalid() (gas: -156 (-0.056%))
testInactiveStrategy() (gas: -666 (-0.056%))
testFloorFromChainlinkPremiumBidTooLow() (gas: -158 (-0.057%))
testFloorFromChainlinkDiscountOraclePriceNotRecentEnough() (gas: -153 (-0.058%))
testFloorFromChainlinkDiscountFixedAmountDesiredDiscountedPriceGreaterThanOrEqualToMaxPrice() (gas: -201 (-0.058%))
testFloorFromChainlinkPremiumBidTooLow() (gas: -162 (-0.059%))
testCannotExecuteAnotherOrderAtNonceIfExecutionIsInProgress(uint256) (gas: -830 (-0.062%))
testThreeTakerBidsGasGriefing() (gas: -306 (-0.064%))
testFloorFromChainlinkPremiumFixedAmountDesiredSalePriceEqualToMinPrice() (gas: -231 (-0.065%))
testFloorFromChainlinkPremiumMakerAskItemIdsLengthNotOne() (gas: -161 (-0.065%))
testAmountGreaterThanOneForERC721() (gas: -184 (-0.066%))
testFloorFromChainlinkPremiumFixedAmountDesiredSalePriceGreaterThanMinPrice() (gas: -236 (-0.066%))
testCannotExecuteOrderIfSubsetNonceIsUsed(uint256) (gas: -144 (-0.068%))
testFloorFromChainlinkPremiumAdditionalParametersNotProvided() (gas: -179 (-0.068%))
testInvalidSelector() (gas: 9 (0.069%))
testFloorFromChainlinkPremiumAdditionalParametersNotProvided() (gas: -183 (-0.070%))
testFloorFromChainlinkPremiumBasisPointsDesiredSalePriceLessThanMinPrice() (gas: -252 (-0.070%))
testCancelOrderNonces(uint256,uint256) (gas: -46 (-0.072%))
testFloorFromChainlinkDiscountAskTooHigh() (gas: -193 (-0.072%))
testFloorFromChainlinkPremiumCurrencyInvalid() (gas: -200 (-0.072%))
testCreatorRoyaltiesRevertIfFeeHigherThanLimit() (gas: -543 (-0.073%))
testFloorFromChainlinkDiscountChainlinkPriceLessThanOrEqualToZero() (gas: -350 (-0.074%))
testInactiveStrategy() (gas: -196 (-0.074%))
testFloorFromChainlinkPremiumFixedAmountDesiredSalePriceLessThanMinPrice() (gas: -276 (-0.077%))
testNewStrategy() (gas: -579 (-0.079%))
testRevertIfInvalidSignatureLength(uint256,uint256,uint256) (gas: -102 (-0.080%))
testFloorFromChainlinkDiscountCurrencyInvalid() (gas: -214 (-0.081%))
testFloorFromChainlinkDiscountMakerBidAmountNotOne() (gas: -238 (-0.081%))
testRevertIfSignatureEOAInvalid(uint256,uint256,uint256) (gas: -261 (-0.082%))
testFloorFromChainlinkDiscountMakerBidAmountNotOne() (gas: -243 (-0.083%))
testUpdateDomainSeparator(uint64) (gas: 22 (0.085%))
testFloorFromChainlinkDiscountAskTooHigh() (gas: -230 (-0.086%))
testFloorFromChainlinkDiscountBasisPointsDesiredDiscountedPriceGreaterThanOrEqualToMaxPrice() (gas: -302 (-0.087%))
testFloorFromChainlinkDiscountBasisPointsDesiredDiscountedPriceLessThanMaxPrice() (gas: -302 (-0.087%))
testFloorFromChainlinkPremiumMakerAskAmountsLengthNotOne() (gas: -223 (-0.089%))
testCannotExecuteOrderIfInvalidUserGlobalAskNonce(uint256) (gas: -192 (-0.089%))
testFloorFromChainlinkDiscountBasisPointsDesiredDiscountBasisPointsGreaterThan10000() (gas: -240 (-0.092%))
testFloorFromChainlinkDiscountPriceFeedNotAvailable() (gas: -193 (-0.092%))
testFloorFromChainlinkPremiumPriceFeedNotAvailable() (gas: -203 (-0.093%))
testEventsAreEmittedAsExpected() (gas: 67 (0.094%))
testFloorFromChainlinkPremiumPriceFeedNotAvailable() (gas: -207 (-0.094%))
testCannotExecuteOrderIfInvalidUserGlobalBidNonce(uint256) (gas: -203 (-0.102%))
testInactiveStrategy() (gas: -276 (-0.103%))
testFloorFromChainlinkDiscountOraclePriceNotRecentEnough() (gas: -276 (-0.104%))
testCannotValidateOrderIfMakerAskItemIdsLengthMismatch(uint256) (gas: -4395 (-0.106%))
testCannotValidateOrderIfMakerBidItemIdsLengthMismatch(uint256) (gas: -4408 (-0.107%))
testFloorFromChainlinkDiscountChainlinkPriceLessThanOrEqualToZero() (gas: -516 (-0.108%))
testUpdateMaxCreatorFeeBp(uint16) (gas: -22 (-0.110%))
testFloorFromChainlinkDiscountCurrencyInvalid() (gas: -297 (-0.112%))
testMakerBidStrategyNotImplemented() (gas: -68 (-0.117%))
testMultipleTakerBidsERC721WithAffiliateButWithoutRoyalty() (gas: -2191 (-0.119%))
testFloorFromChainlinkDiscountPriceFeedNotAvailable() (gas: -276 (-0.131%))
testCannotTradeIfETHIsUsedForMakerBid() (gas: -194 (-0.132%))
testMerkleRootLengthIsNot32() (gas: -196 (-0.132%))
testFloorFromChainlinkDiscountMakerBidAmountsLengthNotOne() (gas: -321 (-0.133%))
testCannotValidateOrderIfTooLateToExecute(uint256) (gas: -175 (-0.133%))
testNewStrategyEventIsEmitted() (gas: 865 (0.148%))
testFloorFromChainlinkDiscountMakerBidAmountsLengthNotOne() (gas: -364 (-0.151%))
testInitialStates() (gas: 42 (0.155%))
testCannotValidateOrderIfMakerAskItemIdsIsEmpty() (gas: -229 (-0.162%))
testRevertIfRecoveredSignerIsNullAddress(uint256,uint256) (gas: -221 (-0.169%))
testSetPriceFeedNotOwner() (gas: 22 (0.172%))
testSetPriceFeedNotOwner() (gas: 22 (0.172%))
testSetPriceFeedNotOwner() (gas: 22 (0.172%))
testUpdateDomainSeparatorSameDomainSeparator() (gas: 23 (0.174%))
testRevertIfInvalidSParameter(uint256,uint256,bytes32) (gas: -221 (-0.178%))
testInvalidSelector() (gas: -31 (-0.179%))
testInvalidSelector() (gas: -31 (-0.179%))
testInvalidSelector() (gas: -31 (-0.179%))
testInvalidSelector() (gas: -31 (-0.179%))
testUpdateMaxCreatorFeeBpTooHigh(uint16) (gas: -22 (-0.186%))
testRevertIfInvalidVParameter(uint256,uint256,uint8) (gas: -243 (-0.194%))
testCannotValidateOrderIfStartTimeLaterThanEndTime(uint256) (gas: -257 (-0.197%))
testAddStrategyNotOwner() (gas: -22 (-0.199%))
testCannotValidateOrderIfTooEarlyToExecute(uint256) (gas: -262 (-0.199%))
testUpdateProtocolFeeRecipientNotOwner() (gas: -22 (-0.208%))
testUpdateMaxCreatorFeeBpNotOwner() (gas: -22 (-0.208%))
testUpdateAffiliateControllerNotOwner() (gas: -22 (-0.208%))
testUpdateCreatorFeeManagerNotOwner() (gas: 22 (0.208%))
testOwnerRevertionsForInvalidParametersAddStrategy() (gas: 44 (0.211%))
testTakerAskMultipleOrdersSignedERC721MerkleProofInvalid() (gas: -43360 (-0.227%))
testTakerBidMultipleOrdersSignedERC721MerkleProofInvalid() (gas: -43650 (-0.230%))
testUpdateProtocolFeeRecipient() (gas: 45 (0.231%))
testCannotValidateOrderIfMakerBidItemIdsIsEmpty() (gas: -303 (-0.236%))
testMakerAskStrategyNotImplemented() (gas: -90 (-0.286%))
testNewStrategy() (gas: -44 (-0.326%))
testNewStrategy() (gas: -44 (-0.326%))
testNewStrategy() (gas: -44 (-0.326%))
testUpdateCreatorFeeManager() (gas: 66 (0.340%))
testSetPriceFeedNotOwner() (gas: -44 (-0.343%))
testNewStrategy() (gas: -44 (-0.386%))
testMaxLatency() (gas: 22 (0.399%))
testMaxLatency() (gas: 22 (0.401%))
testMaxLatency() (gas: 22 (0.401%))
testMaxLatency() (gas: 22 (0.404%))
testUpdateStrategyNotOwner() (gas: 44 (0.406%))
testNewStrategies() (gas: -66 (-0.414%))
testUpdateDomainSeparatorNotOwner() (gas: 44 (0.422%))
testUpdateETHGasLimitForTransferNotOwner() (gas: 45 (0.430%))
testOwnerRevertionsForInvalidParametersUpdateStrategy() (gas: 155 (0.523%))
testCancelNoncesRevertIfEmptyArrays() (gas: 64 (0.620%))
testMaxLatency() (gas: -43 (-0.774%))
testUpdateProtocolFeeRecipientCannotBeNullAddress() (gas: -88 (-0.776%))
testBatchTakerAskOnERC1155BatchReceivedReentrancy() (gas: 67554 (3.870%))
testExecuteMultipleTakerBidsOnERC1155ReceivedReentrancyOnlyInTheLastCall() (gas: 67324 (4.576%))
testTakerAskOnERC1155ReceivedReentrancy() (gas: 67561 (5.745%))
testExecuteMultipleTakerBidsReentrancy() (gas: 67454 (5.932%))
testExecuteMultipleTakerBidsIsValidSignatureReentrancy() (gas: 67454 (5.980%))
testTakerBidReentrancy() (gas: 67617 (6.395%))
testTakerAskReentrancy() (gas: 67555 (6.429%))
testTakerBidIsInvalidSignatureReentrancy() (gas: 67639 (6.520%))
testTakerAskIsValidSignatureReentrancy() (gas: 67577 (6.549%))
Overall gas change: -13318 (42.811%)
```

for readability rather than performance, but overall less gas spent just that the re-entrancy test cases skewed the snapshot.