### PR TITLE
feat: Inherit from batch order registry

### DIFF
--- a/contracts/BatchOrderTypehashRegistry.sol
+++ b/contracts/BatchOrderTypehashRegistry.sol
@@ -5,11 +5,11 @@ pragma solidity 0.8.17;
 import {MerkleProofTooLarge} from "./errors/SharedErrors.sol";
 
 contract BatchOrderTypehashRegistry {
-    function hash(bytes32 root, uint256 proofLength) external pure returns (bytes32 batchOrderTypehash) {
-        batchOrderTypehash = keccak256(abi.encode(getTypehash(proofLength), root));
+    function hashBatchOrder(bytes32 root, uint256 proofLength) public pure returns (bytes32 batchOrderTypehash) {
+        batchOrderTypehash = keccak256(abi.encode(_getBatchOrderTypehash(proofLength), root));
     }
 
-    function getTypehash(uint256 height) public pure returns (bytes32 typehash) {
+    function _getBatchOrderTypehash(uint256 height) internal pure returns (bytes32 typehash) {
         /**
          * It looks like this for each height
          * height == 1: BatchOrder(Maker[2] tree)Maker(uint8 quoteType,uint256 globalNonce,uint256 subsetNonce,uint256 orderNonce,uint256 strategyId,uint8 assetType,address collection,address currency,address signer,uint256 startTime,uint256 endTime,uint256 price,uint256[] itemIds,uint256[] amounts,bytes additionalParameters)

--- a/contracts/LooksRareProtocol.sol
+++ b/contracts/LooksRareProtocol.sol
@@ -74,14 +74,10 @@ contract LooksRareProtocol is
     TransferSelectorNFT,
     LowLevelETHReturnETHIfAnyExceptOneWei,
     LowLevelWETH,
-    LowLevelERC20Transfer
+    LowLevelERC20Transfer,
+    BatchOrderTypehashRegistry
 {
     using OrderStructs for OrderStructs.Maker;
-
-    /**
-     * @notice Typehash registry for batch orders.
-     */
-    BatchOrderTypehashRegistry public immutable batchOrderTypehashRegistry;
 
     /**
      * @notice Wrapped ETH.
@@ -120,7 +116,6 @@ contract LooksRareProtocol is
     ) TransferSelectorNFT(_owner, _protocolFeeRecipient, _transferManager) {
         _updateDomainSeparator();
         WETH = _weth;
-        batchOrderTypehashRegistry = new BatchOrderTypehashRegistry();
     }
 
     /**
@@ -642,7 +637,7 @@ contract LooksRareProtocol is
                 revert MerkleProofInvalid();
             }
 
-            orderHash = batchOrderTypehashRegistry.hash(merkleTree.root, proofLength);
+            orderHash = hashBatchOrder(merkleTree.root, proofLength);
         }
 
         _computeDigestAndVerify(orderHash, signature, signer);

--- a/contracts/helpers/OrderValidatorV2A.sol
+++ b/contracts/helpers/OrderValidatorV2A.sol
@@ -23,7 +23,6 @@ import {OrderInvalid} from "../errors/SharedErrors.sol";
 // Other dependencies
 import {LooksRareProtocol} from "../LooksRareProtocol.sol";
 import {TransferManager} from "../TransferManager.sol";
-import {BatchOrderTypehashRegistry} from "../BatchOrderTypehashRegistry.sol";
 
 // Constants
 import "../constants/ValidationCodeConstants.sol";
@@ -614,8 +613,7 @@ contract OrderValidatorV2A {
                 return ORDER_HASH_PROOF_NOT_IN_MERKLE_TREE;
             }
 
-            BatchOrderTypehashRegistry batchOrderTypehashRegistry = looksRareProtocol.batchOrderTypehashRegistry();
-            bytes32 batchOrderHash = batchOrderTypehashRegistry.hash(merkleTree.root, merkleTree.proof.length);
+            bytes32 batchOrderHash = looksRareProtocol.hashBatchOrder(merkleTree.root, merkleTree.proof.length);
 
             return _computeDigestAndVerify(batchOrderHash, signature, signer);
         } else {

--- a/contracts/helpers/ProtocolHelpers.sol
+++ b/contracts/helpers/ProtocolHelpers.sol
@@ -9,7 +9,6 @@ import {OrderStructs} from "../libraries/OrderStructs.sol";
 
 // Other dependencies
 import {LooksRareProtocol} from "../LooksRareProtocol.sol";
-import {BatchOrderTypehashRegistry} from "../BatchOrderTypehashRegistry.sol";
 
 /**
  * @title ProtocolHelpers
@@ -51,8 +50,7 @@ contract ProtocolHelpers {
      */
     function computeDigestMerkleTree(OrderStructs.MerkleTree memory merkleTree) public view returns (bytes32 digest) {
         bytes32 domainSeparator = looksRareProtocol.domainSeparator();
-        BatchOrderTypehashRegistry batchOrderTypehashRegistry = looksRareProtocol.batchOrderTypehashRegistry();
-        bytes32 batchOrderHash = batchOrderTypehashRegistry.hash(merkleTree.root, merkleTree.proof.length);
+        bytes32 batchOrderHash = looksRareProtocol.hashBatchOrder(merkleTree.root, merkleTree.proof.length);
         return keccak256(abi.encodePacked(_ENCODING_PREFIX, domainSeparator, batchOrderHash));
     }
 

--- a/test/foundry/BatchOrderTypehashRegistry.t.sol
+++ b/test/foundry/BatchOrderTypehashRegistry.t.sol
@@ -8,24 +8,60 @@ import {BatchOrderTypehashRegistry} from "../../contracts/BatchOrderTypehashRegi
 // Shared errors
 import {MerkleProofTooLarge} from "../../contracts/errors/SharedErrors.sol";
 
+contract BatchOrderTypehashRegistryInheriter is BatchOrderTypehashRegistry {
+    function getBatchOrderTypehash(uint256 height) external pure returns (bytes32 typehash) {
+        return _getBatchOrderTypehash(height);
+    }
+}
+
 contract BatchOrderTypehashRegistryTest is Test {
     function testHash() public {
-        BatchOrderTypehashRegistry registry = new BatchOrderTypehashRegistry();
+        BatchOrderTypehashRegistryInheriter registry = new BatchOrderTypehashRegistryInheriter();
         bytes32 root = hex"6942000000000000000000000000000000000000000000000000000000000000";
-        assertEq(registry.hash(root, 1), hex"33c657401cb4cc9871013e0f76f5281e0d120ebe79a7df082ef23f819c88a713");
-        assertEq(registry.hash(root, 2), hex"f512f08b1484881bfeee2fff62ec8ab82802924cf7d60935f439c51ec4c36137");
-        assertEq(registry.hash(root, 3), hex"8526a9764b20d57713475efc2cd5510a66ca8c42cffac8ac53a11b92902f4d2e");
-        assertEq(registry.hash(root, 4), hex"10d2d11a4c31f70fe46acd8bb3da553a486eeb19ca16e142a2cfbf5ad44db13c");
-        assertEq(registry.hash(root, 5), hex"a0e3c51d5b4c0161ef05090b23f65dc9a0a1eeeb41ca7d8273072bd219971736");
-        assertEq(registry.hash(root, 6), hex"0ba773da36db5b6d707566fed81f0467735faa607baa1935879234461aa2a67d");
-        assertEq(registry.hash(root, 7), hex"c6ac7b53bdac5ffacb36b16446b2c42b79b5ae7507cdbe8b7003cdcf5a7cd6b4");
-        assertEq(registry.hash(root, 8), hex"a1b41ffa9ef16d44f213995f30fbc1b5c7b9f2295422690d1b50adcb5b8ef074");
-        assertEq(registry.hash(root, 9), hex"572bca919a81f64902ca93574858cc79353e5cc73cc3b8b0b1c7c65e45df07d6");
-        assertEq(registry.hash(root, 10), hex"e7dee9a17322f61bfe28d8937543ad6efa464090d9699b49e84b0ce9a9850fff");
+        assertEq(
+            registry.hashBatchOrder(root, 1),
+            hex"33c657401cb4cc9871013e0f76f5281e0d120ebe79a7df082ef23f819c88a713"
+        );
+        assertEq(
+            registry.hashBatchOrder(root, 2),
+            hex"f512f08b1484881bfeee2fff62ec8ab82802924cf7d60935f439c51ec4c36137"
+        );
+        assertEq(
+            registry.hashBatchOrder(root, 3),
+            hex"8526a9764b20d57713475efc2cd5510a66ca8c42cffac8ac53a11b92902f4d2e"
+        );
+        assertEq(
+            registry.hashBatchOrder(root, 4),
+            hex"10d2d11a4c31f70fe46acd8bb3da553a486eeb19ca16e142a2cfbf5ad44db13c"
+        );
+        assertEq(
+            registry.hashBatchOrder(root, 5),
+            hex"a0e3c51d5b4c0161ef05090b23f65dc9a0a1eeeb41ca7d8273072bd219971736"
+        );
+        assertEq(
+            registry.hashBatchOrder(root, 6),
+            hex"0ba773da36db5b6d707566fed81f0467735faa607baa1935879234461aa2a67d"
+        );
+        assertEq(
+            registry.hashBatchOrder(root, 7),
+            hex"c6ac7b53bdac5ffacb36b16446b2c42b79b5ae7507cdbe8b7003cdcf5a7cd6b4"
+        );
+        assertEq(
+            registry.hashBatchOrder(root, 8),
+            hex"a1b41ffa9ef16d44f213995f30fbc1b5c7b9f2295422690d1b50adcb5b8ef074"
+        );
+        assertEq(
+            registry.hashBatchOrder(root, 9),
+            hex"572bca919a81f64902ca93574858cc79353e5cc73cc3b8b0b1c7c65e45df07d6"
+        );
+        assertEq(
+            registry.hashBatchOrder(root, 10),
+            hex"e7dee9a17322f61bfe28d8937543ad6efa464090d9699b49e84b0ce9a9850fff"
+        );
     }
 
     function testGetTypehash() public {
-        BatchOrderTypehashRegistry registry = new BatchOrderTypehashRegistry();
+        BatchOrderTypehashRegistryInheriter registry = new BatchOrderTypehashRegistryInheriter();
         bytes memory makerOrderString = bytes(
             "Maker("
             "uint8 quoteType,"
@@ -47,52 +83,52 @@ contract BatchOrderTypehashRegistryTest is Test {
         );
 
         assertEq(
-            registry.getTypehash(1),
+            registry.getBatchOrderTypehash(1),
             keccak256(bytes.concat(bytes("BatchOrder(Maker[2] tree)"), makerOrderString))
         );
 
         assertEq(
-            registry.getTypehash(2),
+            registry.getBatchOrderTypehash(2),
             keccak256(bytes.concat(bytes("BatchOrder(Maker[2][2] tree)"), makerOrderString))
         );
 
         assertEq(
-            registry.getTypehash(3),
+            registry.getBatchOrderTypehash(3),
             keccak256(bytes.concat(bytes("BatchOrder(Maker[2][2][2] tree)"), makerOrderString))
         );
 
         assertEq(
-            registry.getTypehash(4),
+            registry.getBatchOrderTypehash(4),
             keccak256(bytes.concat(bytes("BatchOrder(Maker[2][2][2][2] tree)"), makerOrderString))
         );
 
         assertEq(
-            registry.getTypehash(5),
+            registry.getBatchOrderTypehash(5),
             keccak256(bytes.concat(bytes("BatchOrder(Maker[2][2][2][2][2] tree)"), makerOrderString))
         );
 
         assertEq(
-            registry.getTypehash(6),
+            registry.getBatchOrderTypehash(6),
             keccak256(bytes.concat(bytes("BatchOrder(Maker[2][2][2][2][2][2] tree)"), makerOrderString))
         );
 
         assertEq(
-            registry.getTypehash(7),
+            registry.getBatchOrderTypehash(7),
             keccak256(bytes.concat(bytes("BatchOrder(Maker[2][2][2][2][2][2][2] tree)"), makerOrderString))
         );
 
         assertEq(
-            registry.getTypehash(8),
+            registry.getBatchOrderTypehash(8),
             keccak256(bytes.concat(bytes("BatchOrder(Maker[2][2][2][2][2][2][2][2] tree)"), makerOrderString))
         );
 
         assertEq(
-            registry.getTypehash(9),
+            registry.getBatchOrderTypehash(9),
             keccak256(bytes.concat(bytes("BatchOrder(Maker[2][2][2][2][2][2][2][2][2] tree)"), makerOrderString))
         );
 
         assertEq(
-            registry.getTypehash(10),
+            registry.getBatchOrderTypehash(10),
             keccak256(bytes.concat(bytes("BatchOrder(Maker[2][2][2][2][2][2][2][2][2][2] tree)"), makerOrderString))
         );
     }
@@ -100,8 +136,8 @@ contract BatchOrderTypehashRegistryTest is Test {
     function testGetTypehashMerkleProofTooLarge(uint256 height) public {
         vm.assume(height > 10);
 
-        BatchOrderTypehashRegistry registry = new BatchOrderTypehashRegistry();
+        BatchOrderTypehashRegistryInheriter registry = new BatchOrderTypehashRegistryInheriter();
         vm.expectRevert(abi.encodeWithSelector(MerkleProofTooLarge.selector, height));
-        registry.getTypehash(height);
+        registry.getBatchOrderTypehash(height);
     }
 }

--- a/test/foundry/utils/EIP712MerkleTree.sol
+++ b/test/foundry/utils/EIP712MerkleTree.sol
@@ -35,7 +35,7 @@ contract EIP712MerkleTree is Test {
         if (2 ** treeHeight != bidCount || treeHeight == 0) {
             treeHeight += 1;
         }
-        bytes32 batchOrderTypehash = _getTypehash(treeHeight);
+        bytes32 batchOrderTypehash = _getBatchOrderTypehash(treeHeight);
         uint256 leafCount = 2 ** treeHeight;
         bytes32[] memory leaves = new bytes32[](leafCount);
 
@@ -78,18 +78,33 @@ contract EIP712MerkleTree is Test {
         signature = abi.encodePacked(r, s, v);
     }
 
-    function _getTypehash(uint256 treeHeight) private view returns (bytes32 batchOrderTypehash) {
-        BatchOrderTypehashRegistry batchOrderTypehashRegistry = looksRareProtocol.batchOrderTypehashRegistry();
-        if (treeHeight > MAX_CALLDATA_PROOF_LENGTH) {
-            if (treeHeight == 11) {
-                batchOrderTypehash = hex"9a3ce74af1cf5f60b4762d883e0f75912ccffd3a5a75d18399d9273faed739fb";
-            } else if (treeHeight == 12) {
-                batchOrderTypehash = hex"06195feea862ccec6fab4646f653db6df0ea88e1312269e92c502071c7f57c16";
-            } else if (treeHeight == 13) {
-                batchOrderTypehash = hex"0aa2f1d0d9d5bfd8e18b7fa947f3957ab4283e016dbec7aa4406586fbfabeb85";
-            }
-        } else {
-            batchOrderTypehash = batchOrderTypehashRegistry.getTypehash(treeHeight);
+    function _getBatchOrderTypehash(uint256 treeHeight) private view returns (bytes32 batchOrderTypehash) {
+        if (treeHeight == 1) {
+            batchOrderTypehash = hex"cbbc55854abc707c09d732e7a51c3a1afc570dbbbd52fc5a98e4405f5379b60a";
+        } else if (treeHeight == 2) {
+            batchOrderTypehash = hex"17a0c314d856b89d3cacb1db1904702847910f15e9092b28cfa5ef32ae2b851b";
+        } else if (treeHeight == 3) {
+            batchOrderTypehash = hex"73d811d61eeec3b062bc4e79135b198acd0036360931714173b6d31e8da1838d";
+        } else if (treeHeight == 4) {
+            batchOrderTypehash = hex"9a418ad3a5100c9f4baf19fa46c9863f0cfe8e47ed76281e0b31cf59db8f0d7a";
+        } else if (treeHeight == 5) {
+            batchOrderTypehash = hex"added5faf1d2f37945d7b637b2c838e38814d49c683d79e665d2996f4a2b1ace";
+        } else if (treeHeight == 6) {
+            batchOrderTypehash = hex"ec13b4bc83cfc2d7885d4f0c3cacb5b70d6e85c746f307e63b382deaa1d72e0d";
+        } else if (treeHeight == 7) {
+            batchOrderTypehash = hex"4d13a175331d7cb26822d3f8a43ff58d186b0d7199bbc4a8f3d6bd424fe9329f";
+        } else if (treeHeight == 8) {
+            batchOrderTypehash = hex"06a7cb7b48e9ae3539ba1e484c81abb2618e41ccdc3825b2057a5fd22a17b447";
+        } else if (treeHeight == 9) {
+            batchOrderTypehash = hex"b7a574557d8026c2a7da2f7b5494254ca1367ae18b2118ccdbb6f2f6fe3d1a61";
+        } else if (treeHeight == 10) {
+            batchOrderTypehash = hex"8660a645605d92be3fca6dd485f2662e51c0cd2295a59b3db32bf713fbb81ee4";
+        } else if (treeHeight == 11) {
+            batchOrderTypehash = hex"9a3ce74af1cf5f60b4762d883e0f75912ccffd3a5a75d18399d9273faed739fb";
+        } else if (treeHeight == 12) {
+            batchOrderTypehash = hex"06195feea862ccec6fab4646f653db6df0ea88e1312269e92c502071c7f57c16";
+        } else if (treeHeight == 13) {
+            batchOrderTypehash = hex"0aa2f1d0d9d5bfd8e18b7fa947f3957ab4283e016dbec7aa4406586fbfabeb85";
         }
     }
 }


### PR DESCRIPTION
```
testCreatorRoyaltiesRevertIfFeeHigherThanLimit() (gas: 3 (0.000%))
testMakerAskERC1155BalanceInferiorToAmountThroughBalanceOf() (gas: -12 (-0.001%))
testMakerAskERC1155BalanceOfDoesNotExist() (gas: -12 (-0.001%))
testMakerAskERC1155BalanceInferiorToAmountThroughBalanceOfBatch() (gas: -12 (-0.001%))
testMakerBidWrongAssetTypeERC1155() (gas: -22 (-0.002%))
testMakerAskLooksRareProtocolIsNotAWhitelistedOperator() (gas: -22 (-0.002%))
testInactiveStrategy() (gas: -20 (-0.002%))
testInactiveStrategy() (gas: -22 (-0.002%))
testMakerAskERC1155IsApprovedForAllDoesNotExist() (gas: -34 (-0.002%))
testTakerAskInvalidSignature() (gas: -22 (-0.002%))
testTakerBidInvalidSignature() (gas: -22 (-0.002%))
testExecuteMultipleTakerBidsInvalidSignatures() (gas: -22 (-0.002%))
testExecuteMultipleTakerBidsInvalidSignatures() (gas: -22 (-0.002%))
testCreatorRoyaltiesRevertForEIP2981WithBundlesIfAtLeastOneCallReverts(uint256) (gas: -22 (-0.002%))
testCanSignValidMakerAskEIP2098(uint256,uint256) (gas: 18 (0.003%))
testCanSignValidMakerBidEIP2098(uint256,uint256) (gas: 18 (0.003%))
testTakerAskInvalidSignature() (gas: -34 (-0.004%))
testTakerBidInvalidSignature() (gas: -34 (-0.004%))
testExecuteMultipleTakerBidsReentrancy() (gas: -44 (-0.004%))
testExecuteMultipleTakerBidsIsValidSignatureReentrancy() (gas: -44 (-0.004%))
testCreatorRoyaltiesRevertForEIP2981WithBundlesIfInfoDiffer() (gas: -44 (-0.004%))
testCreatorRoyaltiesRevertForEIP2981WithBundlesIfInfoDiffer() (gas: -44 (-0.005%))
testCreatorRoyaltiesRevertForEIP2981WithBundlesIfAtLeastOneCallReverts(uint256) (gas: -44 (-0.005%))
testMakerAskERC721NotAllTokensAreApproved() (gas: -66 (-0.005%))
testCannotExecuteTransactionIfMakerBidWithStrategyForMakerAsk() (gas: 111 (0.005%))
testCannotExecuteTransactionIfMakerAskWithStrategyForMakerBid() (gas: 112 (0.005%))
testMakerBidERC721AmountNotEqualToOne() (gas: -65 (-0.005%))
testMakerAskWrongAssetTypeERC721() (gas: -66 (-0.006%))
testCannotExecuteAnOrderWhoseNonceIsCancelled(uint256) (gas: -44 (-0.007%))
testInactiveStrategy() (gas: -20 (-0.007%))
testInactiveStrategy() (gas: -20 (-0.007%))
testInactiveStrategy() (gas: -22 (-0.008%))
testInactiveStrategy() (gas: -22 (-0.008%))
testInactiveStrategy() (gas: -20 (-0.008%))
testCannotExecuteOrderIfSubsetNonceIsUsed(uint256) (gas: -22 (-0.010%))
testCannotExecuteOrderIfInvalidUserGlobalBidNonce(uint256) (gas: -22 (-0.011%))
testBatchTakerAskOnERC1155BatchReceivedReentrancy() (gas: 189 (0.011%))
testRevertIfSignatureEOAInvalid(uint256,uint256,uint256) (gas: 38 (0.012%))
testCannotTradeIfCurrencyInvalid() (gas: -66 (-0.012%))
testBatchTakerAsk() (gas: 152 (0.012%))
testCannotValidateOrderIfMakerAskItemIdsIsEmpty() (gas: -20 (-0.014%))
testCannotTradeIfETHIsUsedForMakerBid() (gas: -22 (-0.014%))
testTakerAsk() (gas: 155 (0.015%))
testThreeTakerBidsERC721LengthsInvalid() (gas: -66 (-0.015%))
testTakerBid() (gas: 160 (0.015%))
testCreatorRoyaltiesGetPaidForERC2981WithBundles() (gas: 167 (0.015%))
testTakerAskOnERC1155ReceivedReentrancy() (gas: 189 (0.016%))
testTakerAsk() (gas: 167 (0.016%))
testRevertIfRecoveredSignerIsNullAddress(uint256,uint256) (gas: -22 (-0.016%))
testCannotValidateOrderIfStartTimeLaterThanEndTime(uint256) (gas: -22 (-0.016%))
testTakerBid() (gas: 172 (0.016%))
testCannotValidateOrderIfMakerBidItemIdsIsEmpty() (gas: -22 (-0.016%))
testCreatorRoyaltiesGetPaidForERC2981WithBundles() (gas: 167 (0.017%))
testCannotExecuteOrderIfInvalidUserGlobalAskNonce(uint256) (gas: 38 (0.017%))
testRevertIfInvalidVParameter(uint256,uint256,uint8) (gas: -22 (-0.017%))
testRevertIfInvalidSParameter(uint256,uint256,bytes32) (gas: -22 (-0.017%))
testCreatorRebatesArePaidForRoyaltyFeeManagerWithBundles() (gas: 167 (0.020%))
testTakerAskERC721BundleWithRoyaltiesFromRegistry() (gas: 167 (0.020%))
testCreatorRoyaltiesGetPaidForRoyaltyFeeManagerWithBundles() (gas: 167 (0.020%))
testTakerBidERC721BundleWithRoyaltiesFromRegistry() (gas: 172 (0.020%))
testTakerBidERC1155BundleNoRoyalties() (gas: 160 (0.021%))
testTakerAskERC1155BundleNoRoyalties() (gas: 155 (0.022%))
testTakerBidERC721BundleNoRoyalties() (gas: 172 (0.022%))
testTakerAskERC721BundleNoRoyalties() (gas: 167 (0.022%))
testCannotTradeIfInvalidAmounts() (gas: 152 (0.023%))
testTakerAskERC721WithAffiliateButWithoutRoyalty() (gas: 167 (0.023%))
testTakerAskERC721WithRoyaltiesFromRegistryWithDelegation() (gas: 167 (0.023%))
testTakerBidERC721WithAffiliateButWithoutRoyalty() (gas: 172 (0.024%))
testTakerAskERC721WithRoyaltiesFromRegistry(uint256) (gas: 167 (0.024%))
testCannotExecuteAnOrderTwice() (gas: 167 (0.024%))
testTakerBidERC721WithRoyaltiesFromRegistry(uint256) (gas: 172 (0.024%))
testTakerBidERC721WithRoyaltiesFromRegistryWithDelegation() (gas: 172 (0.024%))
testCreatorRebatesArePaidForRoyaltyFeeManager() (gas: 167 (0.025%))
testCreatorRoyaltiesGetPaidForRoyaltyFeeManager() (gas: 167 (0.025%))
testCreatorRebatesArePaidForERC2981() (gas: 167 (0.025%))
testCreatorRoyaltiesGetPaidForERC2981() (gas: 167 (0.025%))
testTakerBidERC721WithAddressZeroSpecifiedAsRecipient(uint256) (gas: 172 (0.028%))
testTakerAskERC721WithAddressZeroSpecifiedAsRecipient(uint256) (gas: 168 (0.028%))
testCannotValidateOrderIfTooEarlyToExecute(uint256) (gas: 38 (0.028%))
testCannotExecuteMultipleTakerBidsIfDifferentCurrenciesIsNonAtomic() (gas: 172 (0.028%))
testCannotExecuteMultipleTakerBidsIfDifferentCurrenciesIsAtomic() (gas: 172 (0.028%))
testCancelOrderNonces(uint256,uint256) (gas: -22 (-0.034%))
testCannotUpdateAffiliateRateIfRateHigherthan10000() (gas: 23 (0.038%))
testExecuteMultipleTakerBidsOnERC1155ReceivedReentrancyOnlyInTheLastCall() (gas: 560 (0.038%))
testRevertIfInvalidSignatureLength(uint256,uint256,uint256) (gas: 50 (0.039%))
testTakerAskCannotExecuteWithInvalidProof(uint256) (gas: 482 (0.040%))
testTakerBidTooLow(uint256,uint256,uint256,uint256) (gas: 481 (0.042%))
testStartPriceTooLow(uint256,uint256,uint256,uint256) (gas: 481 (0.042%))
testTakerAskUnsortedItemIds() (gas: 482 (0.043%))
testTakerAskDuplicatedItemIds() (gas: 482 (0.043%))
testTakerAskItemIdsAmountsLengthMismatch() (gas: 482 (0.043%))
testTakerAskOfferedAmountNotEqualToDesiredAmount() (gas: 482 (0.043%))
testTakerAskOfferedItemIdTooHigh() (gas: 482 (0.043%))
testTakerAskOfferedItemIdTooLow() (gas: 482 (0.043%))
testZeroDesiredAmount() (gas: 482 (0.044%))
testExecuteMultipleTakerBids() (gas: 560 (0.045%))
testInvalidMakerBidAdditionalParameters() (gas: 482 (0.045%))
testExecuteMultipleTakerBids() (gas: 560 (0.045%))
testItemIdsAndAmountsLengthMismatch() (gas: 481 (0.046%))
testTakerAskRevertsIfProofTooLarge() (gas: -1252716 (-0.048%))
testTakerBidRevertsIfProofTooLarge() (gas: -1252716 (-0.048%))
testZeroItemIdsLength() (gas: 481 (0.049%))
testCannotExecuteAnotherOrderAtNonceIfExecutionIsInProgress(uint256) (gas: 675 (0.050%))
testTakerAskCollectionOrderWithMerkleTreeERC721() (gas: 675 (0.052%))
testCannotExecuteIfNotWETHOrETH() (gas: 503 (0.055%))
testTokenIdsRangeERC721(uint256,uint256) (gas: 675 (0.056%))
testDutchAuction(uint256,uint256,uint256,uint256) (gas: 677 (0.057%))
testTokenIdsRangeERC1155(uint256,uint256) (gas: 663 (0.059%))
testCannotValidateOrderIfTooLateToExecute(uint256) (gas: -82 (-0.060%))
testTakerBidGasGriefing() (gas: 194 (0.061%))
testMultipleTakerBidsERC721WithAffiliateButWithoutRoyalty() (gas: 1354 (0.072%))
testThreeTakerBidsERC721() (gas: 560 (0.073%))
testInitialStates() (gas: -22 (-0.081%))
testTakerAskRevertIfAmountIsZeroOrGreaterThanOneERC721() (gas: 986 (0.086%))
testMakerBidItemIdsLowerBandHigherThanOrEqualToUpperBand() (gas: 986 (0.086%))
testMultiFill() (gas: 1394 (0.087%))
testThreeTakerBidsERC721OneFails() (gas: 1120 (0.109%))
testTakerAskCannotTransferSandboxWithERC721AssetTypeButERC1155AssetTypeWorks() (gas: 378 (0.109%))
testDeriveProtocolParameters() (gas: 45 (0.110%))
testTakerBidCannotTransferSandboxWithERC721AssetTypeButERC1155AssetTypeWorks() (gas: 388 (0.110%))
testTakerAskCollectionOrderERC721(uint256) (gas: 675 (0.110%))
testInvalidAmounts() (gas: 1354 (0.112%))
testUpdateProtocolFeeRecipient() (gas: -22 (-0.113%))
testUpdateCreatorFeeManager() (gas: -22 (-0.113%))
testMakerBidStrategyNotImplemented() (gas: -67 (-0.115%))
testThreeTakerBidsGasGriefing() (gas: 560 (0.116%))
testZeroAmount() (gas: 675 (0.127%))
testMakerBidAmountsLengthNotOne() (gas: 964 (0.163%))
testInvalidAmounts() (gas: 2700 (0.166%))
testFloorFromChainlinkPremiumCurrencyInvalid() (gas: 481 (0.170%))
testFloorFromChainlinkPremiumCurrencyInvalid() (gas: 481 (0.170%))
testFloorFromChainlinkPremiumBidTooLow() (gas: 481 (0.170%))
testFloorFromChainlinkPremiumBidTooLow() (gas: 481 (0.171%))
testFloorFromChainlinkPremiumOraclePriceNotRecentEnough() (gas: 481 (0.172%))
testFloorFromChainlinkPremiumOraclePriceNotRecentEnough() (gas: 481 (0.172%))
testFloorFromChainlinkDiscountAskTooHigh() (gas: 482 (0.176%))
testFloorFromChainlinkDiscountAskTooHigh() (gas: 482 (0.177%))
testFloorFromChainlinkDiscountCurrencyInvalid() (gas: 482 (0.178%))
testFloorFromChainlinkDiscountCurrencyInvalid() (gas: 482 (0.178%))
testFloorFromChainlinkDiscountOraclePriceNotRecentEnough() (gas: 482 (0.179%))
testFloorFromChainlinkDiscountOraclePriceNotRecentEnough() (gas: 482 (0.179%))
testFloorFromChainlinkPremiumAdditionalParametersNotProvided() (gas: 481 (0.179%))
testFloorFromChainlinkPremiumAdditionalParametersNotProvided() (gas: 481 (0.179%))
testFloorFromChainlinkDiscountBasisPointsDesiredDiscountBasisPointsGreaterThan10000() (gas: 482 (0.180%))
testFloorFromChainlinkPremiumBasisPointsDesiredSalePriceLessThanMinPrice() (gas: 677 (0.186%))
testFloorFromChainlinkPremiumFixedAmountDesiredSalePriceLessThanMinPrice() (gas: 677 (0.186%))
testFloorFromChainlinkPremiumFixedAmountDesiredSalePriceGreaterThanMinPrice() (gas: 677 (0.186%))
testFloorFromChainlinkPremiumFixedAmountDesiredSalePriceEqualToMinPrice() (gas: 677 (0.186%))
testFloorFromChainlinkPremiumBasisPointsDesiredSalePriceGreaterThanMinPrice() (gas: 677 (0.187%))
testFloorFromChainlinkPremiumBasisPointsDesiredSalePriceEqualToMinPrice() (gas: 677 (0.187%))
testFloorFromChainlinkPremiumMakerAskAmountsLengthNotOne() (gas: 481 (0.187%))
testFloorFromChainlinkPremiumMakerAskAmountsLengthNotOne() (gas: 481 (0.187%))
testFloorFromChainlinkPremiumMakerAskItemIdsLengthNotOne() (gas: 481 (0.189%))
testFloorFromChainlinkPremiumMakerAskItemIdsLengthNotOne() (gas: 481 (0.189%))
testFloorFromChainlinkDiscountBasisPointsDesiredDiscountedPriceGreaterThanOrEqualToMaxPrice() (gas: 675 (0.191%))
testFloorFromChainlinkDiscountBasisPointsDesiredDiscountedPriceLessThanMaxPrice() (gas: 675 (0.192%))
testFloorFromChainlinkDiscountFixedAmountDesiredDiscountedPriceGreaterThanOrEqualToMaxPrice() (gas: 675 (0.192%))
testFloorFromChainlinkDiscountFixedAmountDesiredDiscountedPriceLessThanMaxPrice() (gas: 675 (0.192%))
testFloorFromChainlinkDiscountMakerBidAmountsLengthNotOne() (gas: 482 (0.195%))
testFloorFromChainlinkDiscountMakerBidAmountsLengthNotOne() (gas: 482 (0.195%))
testTakerBidTooLow() (gas: 481 (0.196%))
testFloorFromChainlinkDiscountChainlinkPriceLessThanOrEqualToZero() (gas: 964 (0.198%))
testFloorFromChainlinkDiscountChainlinkPriceLessThanOrEqualToZero() (gas: 964 (0.198%))
testOraclePriceNotRecentEnough() (gas: 481 (0.198%))
testFloorFromChainlinkPremiumMakerAskAmountNotOne() (gas: 677 (0.210%))
testFloorFromChainlinkPremiumMakerAskAmountNotOne() (gas: 677 (0.210%))
testCancelNoncesRevertIfEmptyArrays() (gas: -22 (-0.213%))
testFloorFromChainlinkPremiumPriceFeedNotAvailable() (gas: 481 (0.214%))
testFloorFromChainlinkPremiumPriceFeedNotAvailable() (gas: 481 (0.214%))
testFloorFromChainlinkDiscountPriceFeedNotAvailable() (gas: 482 (0.223%))
testFloorFromChainlinkDiscountPriceFeedNotAvailable() (gas: 482 (0.223%))
testFloorFromChainlinkPremiumChainlinkPriceLessThanOrEqualToZero() (gas: 984 (0.224%))
testFloorFromChainlinkPremiumChainlinkPriceLessThanOrEqualToZero() (gas: 984 (0.224%))
testUpdateMaxCreatorFeeBp(uint16) (gas: 45 (0.225%))
testFloorFromChainlinkDiscountMakerBidAmountNotOne() (gas: 675 (0.226%))
testFloorFromChainlinkDiscountMakerBidAmountNotOne() (gas: 675 (0.226%))
testAmountGreaterThanOneForERC721() (gas: 677 (0.238%))
testUSDDynamicAskBidderOverpaid() (gas: 699 (0.275%))
testUSDDynamicAskUSDValueLessThanMinAcceptedEthValue() (gas: 699 (0.280%))
testUSDDynamicAskUSDValueLessThanOneETH() (gas: 699 (0.281%))
testUSDDynamicAskUSDValueGreaterThanOrEqualToMinAcceptedEthValue() (gas: 699 (0.281%))
testFloorFromChainlinkDiscountFixedAmountDesiredDiscountedAmountGreaterThanFloorPrice() (gas: 986 (0.310%))
testMerkleRootLengthIsNot32() (gas: 482 (0.314%))
testUSDDynamicAskChainlinkPriceInvalid() (gas: 1006 (0.321%))
testZeroAmount() (gas: 699 (0.327%))
testItemIdsAndAmountsLengthMismatch() (gas: 503 (0.392%))
testCollectionOrderWithMerkleTreeRevertsIfItemIsFlagged() (gas: -298019 (-0.609%))
testZeroItemIdsLength() (gas: 503 (0.662%))
testCannotValidateOrderIfMakerBidItemIdsLengthMismatch(uint256) (gas: 41432 (1.009%))
testCannotValidateOrderIfMakerAskItemIdsLengthMismatch(uint256) (gas: 41524 (1.009%))
testCollectionOrdersWithMerkleTreeAmountsInvalid() (gas: -296187 (-1.424%))
testCollectionOrderWithMerkleTreeWorksIfItemIsNotFlaggedAndLastTransferIsRecentEnough() (gas: -297826 (-1.444%))
testCollectionOrderWithMerkleTreeRevertsIfTransferWithinCooldownPeriodOrTransferCooldownPeriodTooHigh() (gas: -297537 (-1.446%))
testCollectionOrderWithMerkleTreeRevertsIfLastTransferTimeIsZero() (gas: -298019 (-1.455%))
testCollectionOrderWithMerkleTreeRevertsIfItemIdDiffers(uint16) (gas: -298019 (-1.456%))
testCollectionOrderWithMerkleTreeRevertsIfSignatureExpires() (gas: -298019 (-1.456%))
testCollectionOrdersWithMerkleTreeRevertsWithInvalidMerkleProof(uint16) (gas: -298018 (-1.456%))
testCollectionOrderWithMerkleTreeRevertsIfAssetTypeIsNotERC721() (gas: -298019 (-1.457%))
testCollectionOrdersAmountsInvalid() (gas: -296430 (-1.577%))
testCollectionOrderWorksIfItemIsNotFlaggedAndLastTransferIsRecentEnough() (gas: -298069 (-1.601%))
testCollectionOrderRevertsIfTransferWithinCooldownPeriodOrTransferCooldownPeriodTooHigh() (gas: -297780 (-1.604%))
testCollectionOrderRevertsIfItemIsFlagged() (gas: -298262 (-1.614%))
testCollectionOrderRevertsIfLastTransferTimeIsZero() (gas: -298262 (-1.614%))
testCollectionOrderRevertsIfItemIdDiffers(uint16) (gas: -298266 (-1.615%))
testCollectionOrderRevertsIfSignatureExpires() (gas: -298262 (-1.615%))
testCollectionOrderRevertsIfAssetTypeIsNotERC721() (gas: -298262 (-1.615%))
testCollectionOrdersAdditionalParametersLengthInvalid() (gas: -298764 (-1.652%))
testCollectionOrdersWithMerkleTreeAdditionalParametersLengthInvalid() (gas: -298764 (-1.652%))
testHash() (gas: 3413 (1.653%))
testNewStrategies() (gas: -298742 (-1.658%))
testInvalidSelector() (gas: -298742 (-1.658%))
testGetTypehashMerkleProofTooLarge(uint256) (gas: 3434 (1.710%))
testGetTypehash() (gas: 3809 (1.759%))
testTakerBidMultipleOrdersSignedERC721(uint256,uint256) (gas: 33424 (2.917%))
testTakerAskMultipleOrdersSignedERC721(uint256,uint256) (gas: 33618 (2.933%))
testTakerBidMultipleOrdersSignedERC721MerkleProofInvalid(uint256,uint256) (gas: 35039 (3.403%))
testTakerAskMultipleOrdersSignedERC721MerkleProofInvalid(uint256,uint256) (gas: 35237 (3.462%))
Overall gas change: -8468074 (3.204%)
```

not exactly convinced about the gas