### PR TITLE
test: Expect emit all params set to true

### DIFF
--- a/test/foundry/AffiliateManagerAndOrders.t.sol
+++ b/test/foundry/AffiliateManagerAndOrders.t.sol
@@ -52,20 +52,20 @@ contract AffiliateOrdersTest is ProtocolBase, IAffiliateManager {
 
     function test_EventsAreEmittedAsExpected() public asPrankedUser(_owner) {
         // 1. NewAffiliateController
-        vm.expectEmit({checkTopic1: true, checkTopic2: false, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
         emit NewAffiliateController(_owner);
         looksRareProtocol.updateAffiliateController(_owner);
 
         // 2. NewAffiliateProgramStatus
         bool[2] memory boolFlags = _boolFlagsArray();
         for (uint256 i; i < boolFlags.length; i++) {
-            vm.expectEmit({checkTopic1: true, checkTopic2: false, checkTopic3: false, checkData: true});
+            vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
             emit NewAffiliateProgramStatus(boolFlags[i]);
             looksRareProtocol.updateAffiliateProgramStatus(boolFlags[i]);
         }
 
         // 3. NewAffiliateRate
-        vm.expectEmit({checkTopic1: true, checkTopic2: false, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
         emit NewAffiliateRate(takerUser, 30);
         looksRareProtocol.updateAffiliateRate(takerUser, 30);
     }
@@ -122,7 +122,7 @@ contract AffiliateOrdersTest is ProtocolBase, IAffiliateManager {
 
         // Execute taker bid transaction
         vm.prank(takerUser);
-        vm.expectEmit({checkTopic1: true, checkTopic2: false, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
         emit AffiliatePayment(_affiliate, makerAsk.currency, expectedAffiliateFeeAmount);
         looksRareProtocol.executeTakerBid{value: price}(takerBid, makerAsk, signature, _EMPTY_MERKLE_TREE, _affiliate);
 
@@ -175,7 +175,7 @@ contract AffiliateOrdersTest is ProtocolBase, IAffiliateManager {
 
         // Execute taker bid transaction
         vm.prank(takerUser);
-        vm.expectEmit({checkTopic1: true, checkTopic2: false, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
         emit AffiliatePayment(_affiliate, ETH, expectedAffiliateFeeAmount);
         looksRareProtocol.executeMultipleTakerBids{value: price * numberOfPurchases}(
             batchExecutionParameters,
@@ -237,7 +237,7 @@ contract AffiliateOrdersTest is ProtocolBase, IAffiliateManager {
 
         // Execute taker bid transaction
         vm.prank(takerUser);
-        vm.expectEmit({checkTopic1: true, checkTopic2: false, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
         emit AffiliatePayment(_affiliate, address(weth), expectedAffiliateFeeAmount);
         looksRareProtocol.executeMultipleTakerAsks(batchExecutionParameters, _affiliate, false);
 
@@ -299,7 +299,7 @@ contract AffiliateOrdersTest is ProtocolBase, IAffiliateManager {
 
         // Execute taker ask transaction
         vm.prank(takerUser);
-        vm.expectEmit({checkTopic1: true, checkTopic2: false, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
         emit AffiliatePayment(_affiliate, makerBid.currency, expectedAffiliateFeeAmount);
         looksRareProtocol.executeTakerAsk(takerAsk, makerBid, signature, _EMPTY_MERKLE_TREE, _affiliate);
 

--- a/test/foundry/CurrencyManager.t.sol
+++ b/test/foundry/CurrencyManager.t.sol
@@ -23,13 +23,13 @@ contract CurrencyManagerTest is TestHelpers, TestParameters, ICurrencyManager {
 
     function test_UpdateCurrencyStatus() public asPrankedUser(_owner) {
         // Set to true
-        vm.expectEmit({checkTopic1: true, checkTopic2: false, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
         emit CurrencyStatusUpdated(address(mockERC20), true);
         currencyManager.updateCurrencyStatus(address(mockERC20), true);
         assertTrue(currencyManager.isCurrencyAllowed(address(mockERC20)));
 
         // Set to false
-        vm.expectEmit({checkTopic1: true, checkTopic2: false, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
         emit CurrencyStatusUpdated(address(mockERC20), false);
         currencyManager.updateCurrencyStatus(address(mockERC20), false);
         assertFalse(currencyManager.isCurrencyAllowed(address(mockERC20)));

--- a/test/foundry/DomainSeparatorUpdates.t.sol
+++ b/test/foundry/DomainSeparatorUpdates.t.sol
@@ -21,7 +21,7 @@ contract DomainSeparatorUpdatesTest is ProtocolBase {
         vm.assume(newChainId != block.chainid);
 
         vm.chainId(newChainId);
-        vm.expectEmit({checkTopic1: true, checkTopic2: false, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
         emit NewDomainSeparator();
         looksRareProtocol.updateDomainSeparator();
         assertEq(looksRareProtocol.chainId(), newChainId);

--- a/test/foundry/ExecutionManager.t.sol
+++ b/test/foundry/ExecutionManager.t.sol
@@ -25,7 +25,7 @@ contract ExecutionManagerTest is ProtocolBase, IExecutionManager, IStrategyManag
     }
 
     function test_UpdateCreatorFeeManager() public asPrankedUser(_owner) {
-        vm.expectEmit({checkTopic1: true, checkTopic2: false, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
         emit NewCreatorFeeManager(address(1));
         looksRareProtocol.updateCreatorFeeManager(address(1));
         assertEq(address(looksRareProtocol.creatorFeeManager()), address(1));
@@ -38,7 +38,7 @@ contract ExecutionManagerTest is ProtocolBase, IExecutionManager, IStrategyManag
 
     function testFuzz_UpdateMaxCreatorFeeBp(uint16 newMaxCreatorFeeBp) public asPrankedUser(_owner) {
         vm.assume(newMaxCreatorFeeBp <= 2_500);
-        vm.expectEmit({checkTopic1: true, checkTopic2: false, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
         emit NewMaxCreatorFeeBp(newMaxCreatorFeeBp);
         looksRareProtocol.updateMaxCreatorFeeBp(newMaxCreatorFeeBp);
         assertEq(looksRareProtocol.maxCreatorFeeBp(), newMaxCreatorFeeBp);
@@ -56,7 +56,7 @@ contract ExecutionManagerTest is ProtocolBase, IExecutionManager, IStrategyManag
     }
 
     function test_UpdateProtocolFeeRecipient() public asPrankedUser(_owner) {
-        vm.expectEmit({checkTopic1: true, checkTopic2: false, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
         emit NewProtocolFeeRecipient(address(1));
         looksRareProtocol.updateProtocolFeeRecipient(address(1));
         assertEq(looksRareProtocol.protocolFeeRecipient(), address(1));

--- a/test/foundry/GasGriefing.t.sol
+++ b/test/foundry/GasGriefing.t.sol
@@ -48,7 +48,7 @@ contract GasGriefingTest is ProtocolBase {
 
         uint256 sellerProceed = (price * _sellerProceedBpWithStandardProtocolFeeBp) / ONE_HUNDRED_PERCENT_IN_BP;
 
-        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
         emit Deposit(address(looksRareProtocol), sellerProceed);
 
         vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
@@ -107,7 +107,7 @@ contract GasGriefingTest is ProtocolBase {
 
         uint256 sellerProceedPerItem = (price * _sellerProceedBpWithStandardProtocolFeeBp) / ONE_HUNDRED_PERCENT_IN_BP;
 
-        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
         emit Deposit(address(looksRareProtocol), sellerProceedPerItem);
 
         vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});

--- a/test/foundry/LooksRareProtocol.t.sol
+++ b/test/foundry/LooksRareProtocol.t.sol
@@ -131,7 +131,7 @@ contract LooksRareProtocolTest is ProtocolBase {
     }
 
     function test_UpdateETHGasLimitForTransfer() public asPrankedUser(_owner) {
-        vm.expectEmit({checkTopic1: true, checkTopic2: false, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
         emit NewGasLimitETHTransfer(10_000);
         looksRareProtocol.updateETHGasLimitForTransfer(10_000);
         assertEq(uint256(vm.load(address(looksRareProtocol), bytes32(uint256(14)))), 10_000);

--- a/test/foundry/NonceInvalidation.t.sol
+++ b/test/foundry/NonceInvalidation.t.sol
@@ -43,7 +43,7 @@ contract NonceInvalidationTest is INonceManager, ProtocolBase {
         subsetNonces[0] = subsetNonce;
 
         vm.prank(makerUser);
-        vm.expectEmit({checkTopic1: false, checkTopic2: false, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
         emit SubsetNoncesCancelled(makerUser, subsetNonces);
         looksRareProtocol.cancelSubsetNonces(subsetNonces);
 
@@ -77,7 +77,7 @@ contract NonceInvalidationTest is INonceManager, ProtocolBase {
         uint256 newAskNonce = 0 + quasiRandomNumber;
 
         vm.prank(makerUser);
-        vm.expectEmit({checkTopic1: false, checkTopic2: false, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
         emit NewBidAskNonces(makerUser, 0, newAskNonce);
         looksRareProtocol.incrementBidAskNonces(false, true);
 
@@ -121,7 +121,7 @@ contract NonceInvalidationTest is INonceManager, ProtocolBase {
         uint256 newBidNonce = 0 + quasiRandomNumber;
 
         vm.prank(makerUser);
-        vm.expectEmit({checkTopic1: false, checkTopic2: false, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
         emit NewBidAskNonces(makerUser, newBidNonce, 0);
         looksRareProtocol.incrementBidAskNonces(true, false);
 
@@ -307,7 +307,7 @@ contract NonceInvalidationTest is INonceManager, ProtocolBase {
         uint256[] memory orderNonces = new uint256[](2);
         orderNonces[0] = nonceOne;
         orderNonces[1] = nonceTwo;
-        vm.expectEmit({checkTopic1: true, checkTopic2: false, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
         emit OrderNoncesCancelled(makerUser, orderNonces);
         looksRareProtocol.cancelOrderNonces(orderNonces);
 

--- a/test/foundry/ProtocolBase.t.sol
+++ b/test/foundry/ProtocolBase.t.sol
@@ -319,7 +319,7 @@ contract ProtocolBase is MockOrderGenerator, ILooksRareProtocol {
         address[2] memory expectedRecipients,
         uint256[3] memory expectedFees
     ) internal {
-        vm.expectEmit({checkTopic1: true, checkTopic2: false, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
         emit TakerBid(
             NonceInvalidationParameters({
                 orderHash: _computeOrderHash(makerAsk),
@@ -343,7 +343,7 @@ contract ProtocolBase is MockOrderGenerator, ILooksRareProtocol {
         address[2] memory expectedRecipients,
         uint256[3] memory expectedFees
     ) internal {
-        vm.expectEmit({checkTopic1: true, checkTopic2: false, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
         emit TakerAsk(
             NonceInvalidationParameters({
                 orderHash: _computeOrderHash(makerBid),

--- a/test/foundry/StrategyManager.t.sol
+++ b/test/foundry/StrategyManager.t.sol
@@ -50,7 +50,7 @@ contract StrategyManagerTest is ProtocolBase, IStrategyManager {
         uint16 minTotalFeeBp = 200;
         bool isActive = false;
 
-        vm.expectEmit({checkTopic1: false, checkTopic2: false, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
         emit StrategyUpdated(strategyId, isActive, standardProtocolFeeBp, minTotalFeeBp);
         looksRareProtocol.updateStrategy(strategyId, isActive, standardProtocolFeeBp, minTotalFeeBp);
 
@@ -81,7 +81,7 @@ contract StrategyManagerTest is ProtocolBase, IStrategyManager {
         bool isMakerBid = true;
         address implementation = address(strategy);
 
-        vm.expectEmit({checkTopic1: true, checkTopic2: false, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
         emit NewStrategy(
             strategyId,
             _standardProtocolFeeBp,
@@ -104,7 +104,7 @@ contract StrategyManagerTest is ProtocolBase, IStrategyManager {
         uint16 newMinTotalFeeBp = 200;
         bool isActive = true;
 
-        vm.expectEmit({checkTopic1: false, checkTopic2: false, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
         emit StrategyUpdated(strategyId, isActive, newStandardProtocolFeeBp, newMinTotalFeeBp);
         looksRareProtocol.updateStrategy(strategyId, isActive, newStandardProtocolFeeBp, newMinTotalFeeBp);
 

--- a/test/foundry/TransferManager.t.sol
+++ b/test/foundry/TransferManager.t.sol
@@ -43,14 +43,14 @@ contract TransferManagerTest is ITransferManager, TestHelpers, TestParameters {
         address[] memory approvedOperators = new address[](1);
         approvedOperators[0] = _transferrer;
 
-        vm.expectEmit({checkTopic1: true, checkTopic2: false, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
         emit ApprovalsGranted(user, approvedOperators);
         transferManager.grantApprovals(approvedOperators);
     }
 
     function _allowOperator(address transferrer) private {
         vm.prank(_owner);
-        vm.expectEmit({checkTopic1: true, checkTopic2: false, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
         emit OperatorAllowed(transferrer);
         transferManager.allowOperator(transferrer);
     }
@@ -306,7 +306,7 @@ contract TransferManagerTest is ITransferManager, TestHelpers, TestParameters {
 
         // 1. User revokes the operator
         vm.prank(_sender);
-        vm.expectEmit({checkTopic1: false, checkTopic2: false, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
         emit ApprovalsRemoved(_sender, operators);
         transferManager.revokeApprovals(operators);
 
@@ -323,7 +323,7 @@ contract TransferManagerTest is ITransferManager, TestHelpers, TestParameters {
         // 2. Sender grants again approvals but owner removes the operators
         _grantApprovals(_sender);
         vm.prank(_owner);
-        vm.expectEmit({checkTopic1: false, checkTopic2: false, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
         emit OperatorRemoved(_transferrer);
         transferManager.removeOperator(_transferrer);
 
@@ -338,7 +338,7 @@ contract TransferManagerTest is ITransferManager, TestHelpers, TestParameters {
 
         // 1. User revokes the operator
         vm.prank(_sender);
-        vm.expectEmit({checkTopic1: false, checkTopic2: false, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
         emit ApprovalsRemoved(_sender, operators);
         transferManager.revokeApprovals(operators);
 
@@ -355,7 +355,7 @@ contract TransferManagerTest is ITransferManager, TestHelpers, TestParameters {
         // 2. Sender grants again approvals but owner removes the operators
         _grantApprovals(_sender);
         vm.prank(_owner);
-        vm.expectEmit({checkTopic1: false, checkTopic2: false, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
         emit OperatorRemoved(_transferrer);
         transferManager.removeOperator(_transferrer);
 
@@ -370,7 +370,7 @@ contract TransferManagerTest is ITransferManager, TestHelpers, TestParameters {
 
         // 1. User revokes the operator
         vm.prank(_sender);
-        vm.expectEmit({checkTopic1: false, checkTopic2: false, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
         emit ApprovalsRemoved(_sender, operators);
         transferManager.revokeApprovals(operators);
 
@@ -383,7 +383,7 @@ contract TransferManagerTest is ITransferManager, TestHelpers, TestParameters {
         // 2. Sender grants again approvals but owner removes the operators
         _grantApprovals(_sender);
         vm.prank(_owner);
-        vm.expectEmit({checkTopic1: false, checkTopic2: false, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
         emit OperatorRemoved(_transferrer);
         transferManager.removeOperator(_transferrer);
 

--- a/test/foundry/executionStrategies/Chainlink/FloorFromChainlinkOrders.t.sol
+++ b/test/foundry/executionStrategies/Chainlink/FloorFromChainlinkOrders.t.sol
@@ -61,7 +61,7 @@ abstract contract FloorFromChainlinkOrdersTest is ProtocolBase, IStrategyManager
     event PriceFeedUpdated(address indexed collection, address indexed priceFeed);
 
     function testFork_SetPriceFeed() public asPrankedUser(_owner) {
-        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: false});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
         emit PriceFeedUpdated(address(mockERC721), AZUKI_PRICE_FEED);
         strategyFloorFromChainlink.setPriceFeed(address(mockERC721), AZUKI_PRICE_FEED);
         assertEq(strategyFloorFromChainlink.priceFeeds(address(mockERC721)), AZUKI_PRICE_FEED);


### PR DESCRIPTION
https://book.getfoundry.sh/tutorials/best-practices

```
When testing events, prefer setting all expectEmit arguments to true, i.e. vm.expectEmit(true, true, true, true). Benefits:

This ensures you test everything in your event.
If you add a topic (i.e. a new indexed parameter), it's now tested by default.
Even if you only have 1 topic, the extra true arguments don't hurt.
```